### PR TITLE
fix: Update URLs to reflect new opensource-observer org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# OSS Directory  [![License: Apache 2.0][license-badge]][license]
+# OSS Directory [![License: Apache 2.0][license-badge]][license]
 
 [license]: https://opensource.org/license/apache-2-0/
 [license-badge]: https://img.shields.io/badge/License-Apache2.0-blue.svg
 
 This repository contains a curated directory of open source software (OSS) projects and their associated artifacts. Artifacts include git repositories, npm packages, smart contracts, Open Collective collectives, accounts used for managing grant funds, and more. Groups of related projects are organized into collections.
 
-The OSS Directory serves as the "source of truth" for the projects and collections that are discoverable on [Open Source Observer](https://opensource.observer).  
+The OSS Directory serves as the "source of truth" for the projects and collections that are discoverable on [Open Source Observer](https://www.opensource.observer).
 
 While the directory may never be complete, it is actively maintained. We welcome community contributions of new projects and collections, as well as updates to existing entries.
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "oss-directory",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Open source software directory",
-  "repository": "git@github.com:hypercerts-org/oss-directory.git",
-  "author": "Hypercerts Foundation",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opensource-observer/oss-directory.git"
+  },
+  "author": "Kariba Labs",
   "license": "Apache-2.0",
   "bin": "./dist/cli.js",
   "main": "./dist/index.js",

--- a/src/fetchData.ts
+++ b/src/fetchData.ts
@@ -6,7 +6,8 @@ import { Collection } from "./types/collection.js";
 import { Project } from "./types/project.js";
 import { readProjectFile, readCollectionFile } from "./validator/index.js";
 
-const OSS_DIRECTORY_URL = "https://github.com/hypercerts-org/oss-directory.git";
+const OSS_DIRECTORY_URL =
+  "https://github.com/opensource-observer/oss-directory.git";
 const PROJECTS_GLOB = "./data/projects/**/*.yaml";
 const COLLECTIONS_GLOB = "./data/collections/*.yaml";
 


### PR DESCRIPTION
* Fixed package.json repository
* Update fetchData to retrieve from opensource-observer
* Bump version to publish