### PR TITLE
Update omnisea.yaml

### DIFF
--- a/data/projects/o/omnisea.yaml
+++ b/data/projects/o/omnisea.yaml
@@ -2,7 +2,7 @@ version: 3
 slug: omnisea
 name: Omnisea
 github:
-  - url: https://github.com/https://gitlab.com/omnisea
+  - url: https://gitlab.com/omnisea
 blockchain:
   - address: "0xf285e70ca2002b796a575e473285282bbf39d790"
     tags:


### PR DESCRIPTION
Fixes the url for this link. Should we rename this to `repositories`? This is not github @ccerv1