### PR TITLE
Add supermodular + data portal

### DIFF
--- a/data/projects/g/gitcoin-grants-data-portal-davidgasquez.yaml
+++ b/data/projects/g/gitcoin-grants-data-portal-davidgasquez.yaml
@@ -1,0 +1,12 @@
+version: 3
+slug: gitcoin-grants-data-portal-davidgasquez
+name: Gitcoin Grants Data Portal
+github:
+  - url: https://github.com/davidgasquez/gitcoin-grants-data-portal
+blockchain:
+  - address: "0xb9ecee9a0e273d8A1857F3B8EeA30e5dD3cb6335"
+    tags:
+      - wallet
+      - eoa
+    networks:
+      - optimism

--- a/data/projects/s/supermodular-xyz.yaml
+++ b/data/projects/s/supermodular-xyz.yaml
@@ -1,0 +1,5 @@
+version: 3
+slug: supermodular-xyz
+name: Supermodular.xyz
+github:
+  - url: https://github.com/supermodularxyz


### PR DESCRIPTION
Testing community [workflow](https://github.com/opensource-observer/oss-directory/issues/170) for tracking new repositories, adds one user-owned project and one Github org to tracking list. 

Ideally anyone would prefer if those were submitted in bulk, but I am following @ccerv1 to start small to see if I am getting the schema right.

|Entity|Count|Rate|
| --- |---| ---|
| Projects | 2 | 1 USDC |
| Wallet Address| 1 | 0.50 USDC |
| Github Repository | 1 | 0.10 USDC|
| Github Org URL | 1 | 0.50 USDC|