### PR TITLE
fix: tweak variable name

### DIFF
--- a/src/scripts/update_project.py
+++ b/src/scripts/update_project.py
@@ -51,7 +51,7 @@ def append_github_urls(filepath: str, github_url: str) -> None:
     project_data["urls"] = yaml_url_data
     dump(project_data, filepath)
     print(f"Updated {filepath}")
-    replace_single_quotes_with_double_quotes_in_file(project_path)
+    replace_single_quotes_with_double_quotes_in_file(filepath)
 
 
 def update_addresses_from_json(filepath: str) -> None:


### PR DESCRIPTION
I had to monkeypatch this when trying to apply this function as `project_path` does not seem to be defined anywhere within function body. 