### PR TITLE
add: match arbitrum deployers using Dune data

### DIFF
--- a/data/projects/a/aave.yaml
+++ b/data/projects/a/aave.yaml
@@ -19,12 +19,12 @@ blockchain:
       - optimism
   - address: "0x4365f8e70cf38c6ca67de41448508f2da8825500"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xae0b890a625a87c23a1fccdefb4c26a798719f17"
     tags:
       - eoa
@@ -33,29 +33,29 @@ blockchain:
       - optimism
   - address: "0x2401ae9bbef67458362710f90302eb52b5ce835a"
     tags:
-      - factory
       - contract
+      - factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x8145edddf43f50276641b55bd3ad95944510021e"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     name: InitializableImmutableAdminUpgradeabilityProxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xa97684ead0e402dc232d5a977953df7ecbab3cdb"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     name: PoolAddressesProvider
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x9b18398a9bea8bd4c86722c3f467809842aa241c"
     tags:
       - contract
@@ -565,3 +565,17 @@ blockchain:
       - optimism
     tags:
       - contract
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory
+  - address: "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy

--- a/data/projects/a/abracadabra.yaml
+++ b/data/projects/a/abracadabra.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0xfb3485c2e209a5cfbdc1447674256578f1a80ee3"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: 0xcalibur.eth
   - address: "0xfddfe525054efaad204600d00ca86adb1cc2ea8a"
     tags:
@@ -71,12 +71,12 @@ blockchain:
       - optimism
   - address: "0x1ea71cec606f6eecc547937b549e598210ebb0e0"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x2b95bf93b5873c8cb9ae3374e3054736a5b79676"
     tags:
       - contract
@@ -460,12 +460,12 @@ blockchain:
       - optimism
   - address: "0x7c8fef8ea9b1fe46a7689bfb8149341c90431d38"
     tags:
-      - factory
       - contract
+      - factory
     name: ZeroXSolidlyLikeVolatileLPLevSwapper
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x59be9fcb06cc9c8bee44b9861131d4614fb11bda"
     tags:
       - contract
@@ -640,3 +640,10 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x74c764d41b77dbbb4fe771dab1939b00b146894a"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BentoBoxV1

--- a/data/projects/a/across.yaml
+++ b/data/projects/a/across.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0x9a8f92a830a5cb89a3816e3d267cb7791c16b04d"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: across.eth
   - address: "0xb44c433d2b071b95184cf25e1113cc2f1a903cb1"
     tags:
@@ -262,3 +262,10 @@ blockchain:
       - safe
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/a/aloe-ii.yaml
+++ b/data/projects/a/aloe-ii.yaml
@@ -18,13 +18,13 @@ blockchain:
       - optimism
   - address: "0x95110c9806833d3d3c250112fac73c5a6f631e80"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     name: Factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x0000000000f0021d219c5ae2fd5b261966012dd7"
     tags:
       - contract

--- a/data/projects/a/angle-protocol.yaml
+++ b/data/projects/a/angle-protocol.yaml
@@ -330,9 +330,9 @@ blockchain:
       - optimism
   - address: "0xfda462548ce04282f4b6d6619823a7c64fdc0185"
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer

--- a/data/projects/a/arrakis-finance.yaml
+++ b/data/projects/a/arrakis-finance.yaml
@@ -328,19 +328,19 @@ blockchain:
       - optimism
   - address: "0x8a598f5629d3e6a8747afbfd6b9b982a2d1078a1"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xecb8ffcb2369ef188a082a662f496126f66c8288"
     tags:
-      - factory
       - contract
+      - factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: TransparentUpgradeableProxy
   - address: "0xaf0f96e8702cb1b8160e43c8c020c608cd7b134d"
     tags:

--- a/data/projects/a/aura.yaml
+++ b/data/projects/a/aura.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x30019eb135532bddf2da17659101cc000c73c8e4"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xb07d2d6a03f2d4878dc1680f8581e871dae47494"
     tags:
       - eoa
@@ -20,12 +20,12 @@ blockchain:
       - optimism
   - address: "0x53c09096b1dc52e2ef223b2969a714ee75da364f"
     tags:
-      - factory
       - contract
+      - factory
     name: Create2Factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x417d097d504e5adedb441238f92f1b2c9b38900f"
     tags:
       - contract

--- a/data/projects/a/axelar.yaml
+++ b/data/projects/a/axelar.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0xb8cd93c83a974649d76b1c19f311f639e62272bc"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x98b2920d53612483f91f12ed7754e51b4a77919e"
     tags:
       - factory

--- a/data/projects/b/barn-bridge.yaml
+++ b/data/projects/b/barn-bridge.yaml
@@ -90,3 +90,10 @@ blockchain:
     name: EpochAdvancer
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/b/beamer-bridge.yaml
+++ b/data/projects/b/beamer-bridge.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x42405d66fda09dbdac90ff25fc5a4c2353f43e70"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x62249fcb288f0a4734072ab899b926ef9845bc8f"
     tags:
       - contract
@@ -347,12 +347,12 @@ blockchain:
       - optimism
   - address: "0x068053f77e321c8828f5fea91b6917011b1a77fe"
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
   - address: "0x1c7dfaa422cacaa5b368fe22db84b8329cf88e12"
     name: RequestManager
     networks:

--- a/data/projects/b/beefy-finance.yaml
+++ b/data/projects/b/beefy-finance.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0x010da5ff62b6e45f89fa7b2d8ced5a8b5754ec1b"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x982f264ce97365864181df65df4931c593a515ad"
     tags:
       - eoa
@@ -3071,3 +3071,9 @@ blockchain:
     name: XERC20Factory
     networks:
       - optimism
+  - address: "0xfa9da51631268a30ec3ddd1ccbf46c65fad99251"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/b/biconomy.yaml
+++ b/data/projects/b/biconomy.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0xdc0d4bdcc70362cedd23d3997c31528ec1502fc4"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xe3f8154da2aedd10f3cce0ec2bb0da1f1dec2b56"
     tags:
       - contract
@@ -171,12 +171,12 @@ blockchain:
       - optimism
   - address: "0x70717b44011c2f92709168e132e71b02628fbb0c"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xe9a9b272ea05a1ef05aff666665e51cf3a3f9e60"
     tags:
       - contract
@@ -287,11 +287,11 @@ blockchain:
       - factory
   - address: "0xd7eeaa15047b1f6b76dde1d50e298557468d8546"
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     tags:
-      - factory
       - contract
+      - factory
       - proxy
   - address: "0x6b0a5ae0bc0eb03c712ea522aff0a3f09519e4a2"
     networks:

--- a/data/projects/b/bitkeep.yaml
+++ b/data/projects/b/bitkeep.yaml
@@ -18,11 +18,11 @@ blockchain:
       - optimism
   - address: "0x4d176ac0caaa85fc2fd0594573e06458c62a1465"
     tags:
-      - factory
       - contract
+      - factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xcd487bbd5f6f9afd3cea637a1803b6e8d71c958a"
     tags:
       - contract

--- a/data/projects/b/bond-protocol.yaml
+++ b/data/projects/b/bond-protocol.yaml
@@ -58,3 +58,10 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy

--- a/data/projects/c/celer.yaml
+++ b/data/projects/c/celer.yaml
@@ -13,12 +13,12 @@ blockchain:
       - mainnet
   - address: "0x1b9dfc56e38b0f92448659c114e2347bd803911c"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x00778c4222c7d837cbfe4c1539ad10c127ec1c1f"
     tags:
       - eoa
@@ -175,3 +175,10 @@ blockchain:
     name: OptimizedTransparentUpgradeableProxy
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/c/chainlink.yaml
+++ b/data/projects/c/chainlink.yaml
@@ -1814,3 +1814,69 @@ blockchain:
       - optimism
     tags:
       - contract
+  - address: "0x88e104d83599dab09050b4fe9486b3dfa2d3c0de"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0xee895d2955e0ff6bd398cfeccd07a0f879bdc863"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x65297307a79df0c33425720a8e747a428c5271fb"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0xc26e1d9b5acb285b24ea461f02eeed44cab8c0ee"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0xdd0bb8431dd98595024a73c8895d3e6327ce9437"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x71c05a4ea5e9d5b1ac87bf962a043f5265d4bdc8"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0xed3bd4af9e12e87ad59d211dc3817fb871b58e72"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x65543da87649f716d0db9807d0c40cef6419ec32"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x84f3b18e0c17ee9e6f8787a1ad7d13635df629a0"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x66a7fdb96c583c59597de16d8b2b989231415339"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x9e3d8dcd4c4c67eaa752457a51efbf98cb5439c6"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/c/connext.yaml
+++ b/data/projects/c/connext.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0x155b15a7e9ff0e34ceaf2439589d5c661adc9493"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xfd8c6ebe0d284f9d2c9665f17bba47032259e907"
     tags:
       - eoa
@@ -432,12 +432,12 @@ blockchain:
       - optimism
   - address: "0x9f8bd11b264132def2a605091b8cd0ee036804f6"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x92cfe86d3e760302c4822f54d9d3d08fd71703c8"
     tags:
       - contract
@@ -524,3 +524,22 @@ blockchain:
     tags:
       - contract
       - factory
+  - address: "0x2ccc94579056713b2357cb7ce8de054228a1e94b"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x5a041ec279a81f5421667f665767b30dd8e3e36d"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0xee9dec2712cce65174b561151701bf54b99c24c8"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: ConnextDiamond

--- a/data/projects/d/d-hedge.yaml
+++ b/data/projects/d/d-hedge.yaml
@@ -2231,3 +2231,9 @@ blockchain:
       - optimism
     tags:
       - contract
+  - address: "0x1334f737dfe3123653108f4cc4d04b376cd2bcb2"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/d/de-bank.yaml
+++ b/data/projects/d/de-bank.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x5853ed4f26a3fcea565b3fbc698bb19cdf6deb85"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: debanker.eth
   - address: "0x2cc0dc59063ec416fb788edf80d02ebee33d6309"
     tags:

--- a/data/projects/d/debridge-finance.yaml
+++ b/data/projects/d/debridge-finance.yaml
@@ -116,3 +116,10 @@ blockchain:
       - optimism
     tags:
       - contract
+  - address: "0x0b2402144bb366a632d14b83f244d2e0e21bd39c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: TokenBridge

--- a/data/projects/d/decent.yaml
+++ b/data/projects/d/decent.yaml
@@ -408,3 +408,9 @@ blockchain:
       - wallet
     networks:
       - optimism
+  - address: "0xfbe304258dcf193b9a320541985e2078ddb34287"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/d/defiedge.yaml
+++ b/data/projects/d/defiedge.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x001530e763fe9de4dcfe31bbd8548bcb579ebf3a"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x86b86c24c7b1f404ada8b4000acbe04158e096bd"
     tags:
       - eoa
@@ -315,3 +315,36 @@ blockchain:
     name: MiniChefV2
     networks:
       - optimism
+  - address: "0x006b61675a64027144c9eb7cb628becbd14aafa4"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: DefiEdgeTwapStrategyDeployer
+  - address: "0xe1f2331b70ed2dc3723e4e282ec30ecb11359c81"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: WrapperFactory
+  - address: "0xe50952b00178e09e3773b26429832abf34697339"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0xbd6df46aa3cbed7c23e6f844a2db9b1d12cbe033"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: DefiEdgeStrategyDeployer
+  - address: "0x9645fcdc4f740fde63388bdda9b7bddcde99c9cc"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/d/delegatexyz.yaml
+++ b/data/projects/d/delegatexyz.yaml
@@ -20,3 +20,11 @@ blockchain:
       - wallet
     networks:
       - optimism
+  - address: "0x0000000000ffe8b47b3e2130213b802212439497"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy
+    name: ImmutableCreate2Factory

--- a/data/projects/e/elk-finance.yaml
+++ b/data/projects/e/elk-finance.yaml
@@ -66,3 +66,9 @@ blockchain:
     name: SingleStakingRewards
     networks:
       - optimism
+  - address: "0x6bc5fc9d0d908ef8444a7d8f6a7e1a7050a82084"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/f/flashstake.yaml
+++ b/data/projects/f/flashstake.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x4b9f696c998f9549485a3a85dca692fd6cce491f"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x2ba1f7e899948153d8377f77dbb9af25443ff728"
     tags:
       - contract
@@ -90,3 +90,10 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/f/flux-protocol.yaml
+++ b/data/projects/f/flux-protocol.yaml
@@ -9,3 +9,9 @@ blockchain:
       - creator
     networks:
       - optimism
+  - address: "0xbf42f27077014b91031c54751baaacf1d6e79e8e"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/f/fraxfinance.yaml
+++ b/data/projects/f/fraxfinance.yaml
@@ -258,3 +258,23 @@ blockchain:
     tags:
       - contract
       - factory
+  - address: "0x9124b49270a464ddb6f36dc212eee5b1d69d5133"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x93bc2e4061d4b256eb55446952b49c616db4ac0e"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+    name: frax-deployer.eth
+  - address: "0x4600d3b12c39af925c2c07c487d31d17c1e32a35"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+    name: fraxaltdeployer.eth

--- a/data/projects/f/fuji-finance.yaml
+++ b/data/projects/f/fuji-finance.yaml
@@ -14,12 +14,12 @@ blockchain:
       - optimism
   - address: "0x4325018916b082b91e277c7165fd8da6467b71f8"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xd9f99eb83e4b6e48e9d6d015caf28b6b35d07745"
     tags:
       - contract

--- a/data/projects/g/gelato.yaml
+++ b/data/projects/g/gelato.yaml
@@ -24,12 +24,12 @@ blockchain:
       - optimism
   - address: "0x6a0a93cd6d6fb7a36bf6234ef4650bf9474e7682"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x33bf81bdd8185fd1798c493f6937e15d88f89fb0"
     tags:
       - contract
@@ -306,3 +306,21 @@ blockchain:
       - safe
     networks:
       - optimism
+  - address: "0xd1ac051dc0e1366502ef3fe4d754fbec6986a177"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x562c4e878b5cd1f64007358695e8187cb4517c64"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x346389e519536a049588b8adcde807b69a175939"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/g/granary.yaml
+++ b/data/projects/g/granary.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0xe027880ceb8114f2e367211df977899d00e66138"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: granaryfinance.eth
   - address: "0x494bf60b3b58664d5a674e692c718d33687e663a"
     tags:

--- a/data/projects/h/hashflow.yaml
+++ b/data/projects/h/hashflow.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0xe8bc44ae4ba6eddb88c8c087fd9b479dff729850"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xbf0f7012060fa8dca53fe8042256389b24763057"
     tags:
       - contract
@@ -151,3 +151,28 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0xe43632337d3f9a52ffd098fe71a57cc5961c041f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+  - address: "0xac6a83b29e5ff66fd558171ead7ed9d619b055d0"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0xde828fdc3f497f16416d1bb645261c7c6a62dab5"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: HashflowFactory
+  - address: "0x75fb2ab4d5b0de8b1a1acdc9124887d35d459084"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory

--- a/data/projects/h/hedgey-finance.yaml
+++ b/data/projects/h/hedgey-finance.yaml
@@ -31,3 +31,9 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x1247f36104f71d5849d4d4f8a5a95e56b03e7fdd"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/h/holograph.yaml
+++ b/data/projects/h/holograph.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0x0c8af56f7650a6e3685188d212044338c21d3f73"
     tags:
-      - factory
       - contract
+      - factory
     name: HolographGenesis
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x4f92ae4960a6ac49fa88bcf9d6d4b8c53f626a55"
     tags:
       - factory

--- a/data/projects/h/hop-protocol.yaml
+++ b/data/projects/h/hop-protocol.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0x924ac9910c09a0215b06458653b30471a152022f"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xfefec7d3eb14a004029d278393e6ab8b46fb4fca"
     tags:
       - eoa
@@ -26,12 +26,12 @@ blockchain:
       - optimism
   - address: "0x9aa99c23f67c81701c772b106b4f83f6e858dd2e"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x9f93aca246f457916e49ec923b8ed099e313f763"
     tags:
       - contract
@@ -422,3 +422,24 @@ blockchain:
     tags:
       - contract
       - creator
+  - address: "0x10541b07d8ad2647dc6cd67abd4c03575dade261"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: Swap
+  - address: "0x18f7402b673ba6fb5ea4b95768aabb8aad7ef18a"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: Swap
+  - address: "0x652d27c0f72771ce5c76fd400edd61b406ac6d97"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: Swap

--- a/data/projects/h/hundred-finance.yaml
+++ b/data/projects/h/hundred-finance.yaml
@@ -18,12 +18,12 @@ blockchain:
       - optimism
   - address: "0x8fcba7279af1d5d12c77e7062caf1e09a0623f97"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x8286dc6df929c4bfa4f6951cab4dae2ec02d4d72"
     tags:
       - eoa
@@ -499,3 +499,9 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0xfa9da51631268a30ec3ddd1ccbf46c65fad99251"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/i/insuredao.yaml
+++ b/data/projects/i/insuredao.yaml
@@ -88,3 +88,16 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x2c9bc901f39f847c2fe5d2d7ac9c5888a2ab8fcf"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0xeace965860d5a33695a2d08f9fa8c4118a38712f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: Factory

--- a/data/projects/j/jarvis-network.yaml
+++ b/data/projects/j/jarvis-network.yaml
@@ -163,3 +163,10 @@ blockchain:
     name: CreditLineFactory
     networks:
       - optimism
+  - address: "0xe76b6e86cedd9f44957fe0e7729e2c6b4e009b13"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: CreditLineFactory

--- a/data/projects/k/kromatika-finance.yaml
+++ b/data/projects/k/kromatika-finance.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0xdbaabc182e5fcebf216c353a3ebe32cdb7390094"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x3aa2a4f9bc75e34662f7f2877a13a4dda88e00e9"
     tags:
       - contract
@@ -156,3 +156,9 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x9e77c5b95222908d9b0b42e79f6e476c4e7cbf2d"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/k/kyber-swap.yaml
+++ b/data/projects/k/kyber-swap.yaml
@@ -69,12 +69,12 @@ blockchain:
       - optimism
   - address: "0x8de39c1fa14b6082053e7cd937d6ebe58a69d6d2"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xbe2f0354d970265bfc36d383af77f72736b81b54"
     tags:
       - eoa

--- a/data/projects/l/layer-zero.yaml
+++ b/data/projects/l/layer-zero.yaml
@@ -18,20 +18,20 @@ blockchain:
       - optimism
   - address: "0x9f403140bc0574d7d36ea472b82daa1bbd4ef327"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x45208e8d6d09d6bfce5094083ab36f22bdfc8456"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x18606e2abaa0ba15cc1d0d3b55521bd2247e4d2e"
     tags:
       - eoa
@@ -56,12 +56,12 @@ blockchain:
       - optimism
   - address: "0x5e9bf1dd74b4d25b7009af11582f537b08ea3d3c"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x9740ff91f1985d8d2b71494ae1a2f723bb3ed9e4"
     tags:
       - contract

--- a/data/projects/l/lido.yaml
+++ b/data/projects/l/lido.yaml
@@ -33,3 +33,16 @@ blockchain:
     name: L2ERC20TokenBridge
     networks:
       - optimism
+  - address: "0x1824988af7a12c339784a171a514e20609896321"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/l/liquity.yaml
+++ b/data/projects/l/liquity.yaml
@@ -10,3 +10,10 @@ blockchain:
     tags:
       - safe
       - wallet
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/l/lyra-finance.yaml
+++ b/data/projects/l/lyra-finance.yaml
@@ -2072,3 +2072,16 @@ blockchain:
     tags:
       - safe
       - wallet
+  - address: "0xebe8078f9bb79f8c90c1a8dcfc6a830ab75a6b33"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/m/maker-dao.yaml
+++ b/data/projects/m/maker-dao.yaml
@@ -310,9 +310,23 @@ github:
 blockchain:
   - address: "0x075da589886ba445d7c7e81c472059de7ae65250"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
+    networks:
+      - optimism
+      - arbitrum
+  - address: "0x322d58b9e75a6918f7e7849aee0ff09369977e08"
     networks:
       - arbitrum
-      - optimism
+    tags:
+      - eoa
+      - deployer
+    name: donate.cdpsaver.eth
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/m/manifold.yaml
+++ b/data/projects/m/manifold.yaml
@@ -78,3 +78,11 @@ blockchain:
     tags:
       - eoa
       - creator
+  - address: "0x0000000000ffe8b47b3e2130213b802212439497"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy
+    name: ImmutableCreate2Factory

--- a/data/projects/m/mean-finance.yaml
+++ b/data/projects/m/mean-finance.yaml
@@ -48,12 +48,12 @@ blockchain:
       - optimism
   - address: "0xd4c187cd5839bd4b0a2f0d33b199a4ec67d9c67c"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xffd70dfac9fdedc2054860aafe7ea0b13d03c1a7"
     tags:
       - contract
@@ -391,12 +391,12 @@ blockchain:
       - optimism
   - address: "0xf6c6dbe19048d9408a2370db42853541db5ee76e"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x398c8801a261a085505da6208f1e661ea8896b9f"
     tags:
       - contract
@@ -435,20 +435,20 @@ blockchain:
       - optimism
   - address: "0x6197032eddb984c36c5f9c8b705395d048cb1bd2"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x8d2e6971cd20052794fb54e18da69ff4ee5251e6"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x93d30e02a4733db3c3c09ecc89bf83138f594de0"
     tags:
       - contract
@@ -475,12 +475,12 @@ blockchain:
       - optimism
   - address: "0x4db35376875dca2f14ec340da6349a7c0e3542d1"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xe1f1bc74bee3c15843d142a3d1a27307b11aec9b"
     tags:
       - contract

--- a/data/projects/m/metamask.yaml
+++ b/data/projects/m/metamask.yaml
@@ -30,11 +30,11 @@ blockchain:
       - optimism
   - address: "0x2252e2407e61efa6e6ab3a7d33ac6f033486c700"
     tags:
-      - factory
       - contract
+      - factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x82e0b8cdd80af5930c4452c684e71c861148ec8a"
     tags:
       - contract

--- a/data/projects/m/mummy-finance.yaml
+++ b/data/projects/m/mummy-finance.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x30b12942912cee5a719edec2dd147224fcc373a0"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: mmyvote.eth
   - address: "0xb471865c97a271e1572ecca838b971e710498e4c"
     tags:

--- a/data/projects/n/nftearth.yaml
+++ b/data/projects/n/nftearth.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0xcd0b087e113152324fca962488b4d9beb6f4caf6"
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
   - address: "0x0f9b80fc3c8b9123d0aef43df58ebdbc034a8901"
     name: Seaport
     networks:

--- a/data/projects/n/nifty-kit.yaml
+++ b/data/projects/n/nifty-kit.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x9db006063ee2049a35624bcce32945e524105401"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x8d162be635d78f68b9cf1906e96549426b14dc30"
     tags:
       - contract

--- a/data/projects/o/olympus.yaml
+++ b/data/projects/o/olympus.yaml
@@ -32,3 +32,9 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x1a5309f208f161a393e8b5a253de8ab894a67188"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/o/open-sea.yaml
+++ b/data/projects/o/open-sea.yaml
@@ -98,3 +98,19 @@ blockchain:
     tags:
       - contract
       - factory
+  - address: "0x00000000f9490004c11cef243f5400493c00ad63"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy
+    name: ConduitController
+  - address: "0x0000000000ffe8b47b3e2130213b802212439497"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy
+    name: ImmutableCreate2Factory

--- a/data/projects/o/openocean-finance.yaml
+++ b/data/projects/o/openocean-finance.yaml
@@ -17,3 +17,9 @@ blockchain:
     networks:
       - optimism
     name: OpenOceanExchangeProxy
+  - address: "0x920fae61b835bbcc50f0e8883f7de26ce9a2047b"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/o/orbiter-finance.yaml
+++ b/data/projects/o/orbiter-finance.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x8a700fdb6121a57c59736041d9aa21dfd8820660"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xd9d74a29307cc6fc8bf424ee4217f1a587fbc8dc"
     tags:
       - contract

--- a/data/projects/o/overnight.yaml
+++ b/data/projects/o/overnight.yaml
@@ -13,12 +13,12 @@ blockchain:
       - mainnet
   - address: "0x5cb01385d3097b6a189d1ac8ba3364d900666445"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: ovnstable.eth
   - address: "0xb3285706c1b8b11fb5bc0de4be380066d2cb26d0"
     tags:

--- a/data/projects/p/paraswap.yaml
+++ b/data/projects/p/paraswap.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0xf01121e808f782d7f34e857c27da31ad1f151b39"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x05182e579fdfcf69e4390c3411d8fea1fb6467cf"
     tags:
       - eoa
@@ -202,3 +202,17 @@ blockchain:
     name: DirectSwap
     networks:
       - optimism
+  - address: "0x22f3bdd1135e62ba7ee980ed53ded634e412869c"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x8373c68629191ef10f654ce8e32bbfe3c7a1d743"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy
+    name: SmartVaultsFactory

--- a/data/projects/p/pendle-finance.yaml
+++ b/data/projects/p/pendle-finance.yaml
@@ -18,12 +18,12 @@ blockchain:
       - creator
   - address: "0x1fccc097db89a86bfc474a1028f93958295b1fb7"
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
   - address: "0xfc7a495389cd3454f5cc0ecaa55d30e343a1fc16"
     name: LiquiditySeedingHelper
     networks:
@@ -199,11 +199,11 @@ blockchain:
   - address: "0x28de02ac3c3f5ef427e55c321f73fdc7f192e8e4"
     name: PendleSwap
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     tags:
-      - factory
       - contract
+      - factory
   - address: "0x418273abdeafe67c811a7671e5406e15bba10870"
     name: BaseSplitCodeFactoryContract
     networks:
@@ -267,8 +267,23 @@ blockchain:
   - address: "0xf5a7de2d276dbda3eef1b62a9e718eff4d29ddc8"
     name: PendleYieldContractFactoryV2
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     tags:
-      - factory
       - contract
+      - factory
+  - address: "0x0000000000ffe8b47b3e2130213b802212439497"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy
+    name: ImmutableCreate2Factory
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/p/pickle-finance.yaml
+++ b/data/projects/p/pickle-finance.yaml
@@ -541,3 +541,10 @@ blockchain:
     name: StrategyEthUsdcUniV3Optimism
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/p/premiafinance.yaml
+++ b/data/projects/p/premiafinance.yaml
@@ -13,12 +13,12 @@ blockchain:
       - wallet
   - address: "0xc7f8d87734ab2cbf70030ac8aa82abfe3e8126cb"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x48d49466cb2efbf05faa5fa5e69f2984edc8d1d7"
     tags:
       - contract
@@ -109,11 +109,11 @@ blockchain:
       - optimism
   - address: "0x89b36ce3491f2258793c7408bd46aac725973ba2"
     tags:
-      - factory
       - contract
+      - factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: Premia
   - address: "0x14ac2da11c2cf07ea4c64c83be108b8f11e48f20"
     tags:
@@ -383,3 +383,10 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/p/pwnfinance.yaml
+++ b/data/projects/p/pwnfinance.yaml
@@ -11,3 +11,10 @@ blockchain:
     networks:
       - optimism
     name: RPGF3 Payout Address
+  - address: "0x706c9f2dd328e2c01483ecf705d2d9708f4ab727"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: PWNDeployer

--- a/data/projects/r/rabbithole.yaml
+++ b/data/projects/r/rabbithole.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0x017f8ad14a2e745ea0f756bd57cd4852400be78c"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x52629961f71c1c2564c5aa22372cb1b9fa9eba3e"
     tags:
       - contract
@@ -513,3 +513,10 @@ blockchain:
       - optimism
     tags:
       - contract
+  - address: "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy

--- a/data/projects/r/rainbow.yaml
+++ b/data/projects/r/rainbow.yaml
@@ -64,3 +64,10 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/r/rango-exchange.yaml
+++ b/data/projects/r/rango-exchange.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x7e8a8b130272430008eca062419acd8b423d339d"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xb22841ef2ec2c820c0d0fc5370f765791668f50c"
     tags:
       - contract

--- a/data/projects/r/ren.yaml
+++ b/data/projects/r/ren.yaml
@@ -19,11 +19,11 @@ blockchain:
       - optimism
   - address: "0x2222229fb3318a6375fa78fd299a9a42ac6a8fbf"
     tags:
-      - factory
       - contract
+      - factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xf7cb7d42f337085522cc334660474e0d78f89391"
     tags:
       - contract

--- a/data/projects/r/revert-finance.yaml
+++ b/data/projects/r/revert-finance.yaml
@@ -13,12 +13,12 @@ blockchain:
       - mainnet
   - address: "0x8df57e3d9ddde355dce1adb19ebce93419ffa0fb"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x5411894842e610c4d0f6ed4c232da689400f94a1"
     tags:
       - contract
@@ -99,3 +99,9 @@ blockchain:
     networks:
       - optimism
     name: AutoExit
+  - address: "0x83681c14770b44361e21faf91d8325423365ea5c"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/r/rocket-pool.yaml
+++ b/data/projects/r/rocket-pool.yaml
@@ -16,3 +16,10 @@ blockchain:
       - creator
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/r/router-protocol.yaml
+++ b/data/projects/r/router-protocol.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0xb00b19938346b745ccb3fc4fad946de0caa724a2"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xb00bc9e04698a3315b6038225a2e9e42d63c7669"
     tags:
       - eoa

--- a/data/projects/r/rubicon.yaml
+++ b/data/projects/r/rubicon.yaml
@@ -646,12 +646,12 @@ blockchain:
       - optimism
   - address: "0xc96495c314879586761d991a2b68ebeab12c03fe"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xd4dcb4e92b0f434f1297d5239a3aad875e25f675"
     tags:
       - contract

--- a/data/projects/s/sablier.yaml
+++ b/data/projects/s/sablier.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x0298f4332e3857631385b39766325058a93e249f"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x6c5927c0679e6d857e87367bb635decbcb20f31c"
     tags:
       - contract
@@ -29,3 +29,10 @@ blockchain:
     tags:
       - eoa
       - creator
+  - address: "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy

--- a/data/projects/s/saddle-finance.yaml
+++ b/data/projects/s/saddle-finance.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x5bdb37d0ddea3a90f233c7b7f6b9394b6b2eef34"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xa9a84238098dc3d1529228e6c74dbe7ebdf117a5"
     tags:
       - contract
@@ -91,11 +91,11 @@ blockchain:
       - optimism
   - address: "0xbea9f78090bdb9e662d8cb301a00ad09a5b756e9"
     tags:
-      - factory
       - contract
+      - factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: SwapFlashLoan
   - address: "0xcf70e2f3567ba396f3dd04822f78ecd70ba46894"
     tags:
@@ -163,3 +163,58 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x979b44cfc7a9b54bed8a3c4fd674b09c194219fd"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0xa5bd85ed9fa27ba23bfb702989e7218e44fd4706"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: MetaSwap
+  - address: "0xb2a2764d0dcab445e24f4b813be3f6ef8ae5f84d"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: MetaSwap
+  - address: "0xf8504e92428d65e56e495684a38f679c1b1dc30b"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: MetaSwap
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory
+  - address: "0x5dd186f8809147f96d3ffc4508f3c82694e58c9c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: MetaSwap
+  - address: "0x401afbc31ad2a3bc0ed8960d63efcdea749b4849"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: SwapFlashLoan
+  - address: "0xfeea4d1bacb0519e8f952460a70719944fe56ee0"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: SwapFlashLoan

--- a/data/projects/s/slingshot.yaml
+++ b/data/projects/s/slingshot.yaml
@@ -13,12 +13,12 @@ blockchain:
       - mainnet
   - address: "0x44045fd5d3840fec51b76fb6a87cbcda735a8629"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xedd118e091eee0e7fa9eeb9b4db717518f56cb15"
     tags:
       - contract

--- a/data/projects/s/socket.yaml
+++ b/data/projects/s/socket.yaml
@@ -14,20 +14,20 @@ blockchain:
       - optimism
   - address: "0x5fd7d0d6b91cc4787bcb86ca47e0bd4ea0346d34"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x0e1b5ab67af1c99f8c7ebc71f41f75d4d6211e53"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x86791c7b7ea5f77b1612ecc300dd44ba3a1c9083"
     tags:
       - eoa
@@ -85,12 +85,12 @@ blockchain:
       - optimism
   - address: "0x17b1007fa5d96e75f6733e3790dccfaeeda7e5ff"
     tags:
-      - factory
       - contract
+      - factory
       - proxy
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x777d93f5d48b1e838e630fa02dfb2c11db8ef8df"
     tags:
       - contract
@@ -1598,3 +1598,10 @@ blockchain:
       - optimism
     tags:
       - contract
+  - address: "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy

--- a/data/projects/s/stargate-finance.yaml
+++ b/data/projects/s/stargate-finance.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0x1d7c6783328c145393e84fb47a7f7c548f5ee28d"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x6ece61d29b90642941c41240da924690da145696"
     tags:
       - eoa
@@ -233,3 +233,22 @@ blockchain:
       - optimism
     tags:
       - contract
+  - address: "0x55bdb4164d28fbaf0898e0ef14a589ac09ac9970"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: Factory
+  - address: "0x5c85a7ae2b6d29c38cdf360553f8acbc4e684c31"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x937b94dc8c81ed42b2ada5855b220f098568b2be"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/s/sushi.yaml
+++ b/data/projects/s/sushi.yaml
@@ -12,12 +12,12 @@ blockchain:
       - optimism
   - address: "0xf87bc5535602077d340806d71f805ea9907a843d"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x4bb4c1b0745ef7b4642feeccd0740dec417ca0a0"
     tags:
       - eoa
@@ -123,12 +123,12 @@ blockchain:
       - optimism
   - address: "0xc35dadb65012ec5796536bd9864ed8773abc74c4"
     tags:
-      - factory
       - contract
+      - factory
     name: BentoBox
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xd045d27c1f7e7f770a807b0a85d8e3f852e0f2be"
     tags:
       - contract
@@ -280,12 +280,12 @@ blockchain:
       - optimism
   - address: "0x1af415a1eba07a4986a52b6f2e7de7003d82231e"
     tags:
-      - factory
       - contract
+      - factory
     name: NonfungiblePositionManager
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xf60e5f4a44a510742457d8064ffd360b12d8d9af"
     tags:
       - contract
@@ -345,3 +345,9 @@ blockchain:
       - optimism
     tags:
       - contract
+  - address: "0x32464be3d71ed9105c142fb6bdee98a0c649cdd3"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/s/symbiosis-finance.yaml
+++ b/data/projects/s/symbiosis-finance.yaml
@@ -109,3 +109,10 @@ blockchain:
     tags:
       - contract
       - factory
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/s/synapse.yaml
+++ b/data/projects/s/synapse.yaml
@@ -14,12 +14,12 @@ blockchain:
       - optimism
   - address: "0x0af91fa049a7e1894f480bfe5bba20142c6c29a9"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: aurelius0x.eth
   - address: "0x22cdc93f53ee3f6b8ad66fad6f98915a5349950e"
     name: SynapseERC20Factory
@@ -50,12 +50,12 @@ blockchain:
       - optimism
   - address: "0x890bc5691e6011f580e264065d09a7a1a6902131"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xf44938b0125a6662f9536281ad2cd6c499f22004"
     name: SwapFlashLoan
     tags:
@@ -340,3 +340,17 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0xd5609cd0e1675331e4fb1d43207c8d9d83aab17c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: SynapseERC20Factory
+  - address: "0x9695fa23b27022c7dd752b7d64bb5900677ecc21"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: SwapDeployer

--- a/data/projects/t/tarot-finance.yaml
+++ b/data/projects/t/tarot-finance.yaml
@@ -13,12 +13,12 @@ blockchain:
       - mainnet
   - address: "0x5b0390bccca1f040d8993eb6e4ce8ded93721765"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x952e9c6391d9c0f6c6174d395aa9b4ec1030335a"
     tags:
       - contract

--- a/data/projects/t/thales.yaml
+++ b/data/projects/t/thales.yaml
@@ -12,20 +12,20 @@ blockchain:
       - optimism
   - address: "0x9841484a4a6c0b61c4eea71376d76453fd05ec9c"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x8314125c8b68af2afd0d151eb4a551e88128a2ae"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x2d356b114cbca8deff2d8783eac2a5a5324fe1df"
     tags:
       - contract
@@ -3344,12 +3344,12 @@ blockchain:
       - optimism
   - address: "0xe2881cad27db4c27fb3814ad97cca694b80c0fa0"
     tags:
-      - factory
       - contract
+      - factory
     name: BinaryOptionMarketData
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x51f1e255a9f82578bf2c004576c4bc84cb9dd8f7"
     tags:
       - contract
@@ -3714,3 +3714,15 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x8559027bac39638438ddb32d713f0b12ef66ea7b"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x34ad8d8c3e12b5a500fe983c43f2a0306dcf0ad1"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/t/third-web.yaml
+++ b/data/projects/t/third-web.yaml
@@ -26,12 +26,12 @@ npm:
 blockchain:
   - address: "0xdd99b75f095d0c4d5112ace938e4e6ed962fb024"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: deployer.thirdweb.eth
   - address: "0x76f948e5f13b9a84a81e5681df8682bbf524805e"
     tags:

--- a/data/projects/t/tokenbound.yaml
+++ b/data/projects/t/tokenbound.yaml
@@ -10,3 +10,10 @@ blockchain:
     tags:
       - safe
       - wallet
+  - address: "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy

--- a/data/projects/t/transit-finance.yaml
+++ b/data/projects/t/transit-finance.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x280333c41a9302448ebc070ed0300ad2ed4b8244"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xb45a2dda996c32e93b8c47098e90ed0e7ab18e39"
     tags:
       - contract

--- a/data/projects/u/umbra.yaml
+++ b/data/projects/u/umbra.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x5777aa6f437399af6cef2fce0be8d4b4ed7c7232"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0xfb2dc580eed955b528407b4d36ffafe3da685401"
     tags:
       - contract

--- a/data/projects/u/uniswap.yaml
+++ b/data/projects/u/uniswap.yaml
@@ -124,12 +124,12 @@ blockchain:
     name: Uniswap Foundation Custody
   - address: "0x6c9fc64a53c1b71fb3f9af64d1ae3a4931a5f4e9"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x1b5caa1d3a1582a438e4cd93ee7a7e0e4d5624fb"
     tags:
       - eoa
@@ -138,28 +138,28 @@ blockchain:
       - optimism
   - address: "0xd8fa8f87129c654a6dd7f34eedaf58379e176eb1"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x946e9c780f3c79d80e51e68d259d0d7e794f2124"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x1f98431c8ad98523631ae4a59f267346ea31f984"
     name: UniswapV3Factory
     tags:
-      - factory
       - contract
+      - factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad"
     name: UniversalRouter
     tags:
@@ -269,3 +269,23 @@ blockchain:
     name: UnsupportedProtocol
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory
+  - address: "0x18dc1fccea2f4f6dd22ddbf0bed638bc358db625"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer
+  - address: "0x4e59b44847b379578588920ca78fbf26c0b4956c"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy

--- a/data/projects/u/unlock-protocol.yaml
+++ b/data/projects/u/unlock-protocol.yaml
@@ -40,3 +40,16 @@ blockchain:
     networks:
       - optimism
     name: RPGF3 Payout Address
+  - address: "0x1ff7e338d5e582138c46044dc238543ce555c963"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: TransparentUpgradeableProxy
+  - address: "0x81a662065d5c83fa9c5c12d0dc0104df57f85a12"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/v/valioxyz.yaml
+++ b/data/projects/v/valioxyz.yaml
@@ -11,3 +11,9 @@ blockchain:
     networks:
       - optimism
     name: RPGF3 Payout Address
+  - address: "0x7d57d22bf8a1319e3cf897e1aa2347a00f11f36c"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/v/vmex-finance.yaml
+++ b/data/projects/v/vmex-finance.yaml
@@ -11,3 +11,10 @@ blockchain:
     networks:
       - optimism
     name: RPGF3 Payout Address
+  - address: "0x47a61eb4a66e68ca522e998e6c163c880845c5a9"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: LendingPoolAddressesProvider

--- a/data/projects/w/warden-swap.yaml
+++ b/data/projects/w/warden-swap.yaml
@@ -13,12 +13,12 @@ blockchain:
       - mainnet
   - address: "0xbe9228ce3b7ed30c8646143d0e56ee16fec6c07c"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x7ea8c22e6dcd7bd69eb180664da68e1f1f11d696"
     tags:
       - contract
@@ -116,3 +116,9 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x5e12ae8e436cd25f0041d931f8e4c7a3bb42cc1f"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/w/wido.yaml
+++ b/data/projects/w/wido.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x2313f80d53c649c7b2c9c4d101b796f34cbe80f3"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x9b2ed3c2a92ad366ebf90bbcec31be231320ac26"
     tags:
       - contract

--- a/data/projects/w/wombat-exchange.yaml
+++ b/data/projects/w/wombat-exchange.yaml
@@ -10,3 +10,9 @@ blockchain:
     tags:
       - safe
       - wallet
+  - address: "0xcb3bb767104e0b3235520fafb182e005d7efd045"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/w/wormhole.yaml
+++ b/data/projects/w/wormhole.yaml
@@ -7,12 +7,12 @@ github:
 blockchain:
   - address: "0xe2e2d9e31d7e1cc1178fe0d1c5950f6c809816a3"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x1d68124e65fafc907325e3edbf8c4d84499daa8b"
     tags:
       - contract

--- a/data/projects/x/x-dao.yaml
+++ b/data/projects/x/x-dao.yaml
@@ -6,28 +6,28 @@ github:
 blockchain:
   - address: "0x5befa2d163e40e148df83921e1cc59e044df5471"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x72cc6e4de47f673062c41c67505188144a0a3d84"
     tags:
-      - factory
       - contract
+      - factory
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
     name: Factory
   - address: "0xca49ecf7e7bb9bbc9d1d295384663f6ba5c0e366"
     tags:
-      - factory
       - contract
+      - factory
     name: Shop
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x71eeba415a523f5c952cc2f06361d5443545ad28"
     tags:
       - contract
@@ -38,3 +38,9 @@ blockchain:
       - contract
     networks:
       - optimism
+  - address: "0x1a37aa615c3bd23b5c1cecd506a59927133414b9"
+    networks:
+      - arbitrum
+    tags:
+      - eoa
+      - deployer

--- a/data/projects/x/x-token.yaml
+++ b/data/projects/x/x-token.yaml
@@ -238,3 +238,10 @@ blockchain:
     name: RewardEscrowProxy
     networks:
       - optimism
+  - address: "0x3fe38087a94903a9d946fa1915e1772fe611000f"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+    name: BeaconProxyFactory

--- a/data/projects/z/zerion.yaml
+++ b/data/projects/z/zerion.yaml
@@ -6,12 +6,12 @@ github:
 blockchain:
   - address: "0x161b29d1919d4e06b53ee449376181b5082b30b9"
     tags:
-      - deployer
-      - eoa
       - creator
+      - eoa
+      - deployer
     networks:
-      - arbitrum
       - optimism
+      - arbitrum
   - address: "0x014040c6a9cd6366f8fa858535b7ddfac507db20"
     tags:
       - eoa

--- a/data/projects/z/zeroex.yaml
+++ b/data/projects/z/zeroex.yaml
@@ -182,3 +182,10 @@ blockchain:
     tags:
       - eoa
       - creator
+  - address: "0x6b57347d5b0846a0dce87c8e2db45c8da25b97e0"
+    networks:
+      - arbitrum
+    tags:
+      - contract
+      - factory
+      - proxy


### PR DESCRIPTION
Matches existing slugs with (mostly) 'deployer' arbitrum addresses obtained from dune. 

Feel free to add additional context here. EDIT: Removing duplicates...