### PR TITLE
Create layer3xyz.yaml

### DIFF
--- a/data/projects/l/layer3xyz.yaml
+++ b/data/projects/l/layer3xyz.yaml
@@ -1,0 +1,81 @@
+version: 3
+slug: layer3xyz
+name: Layer3
+github:
+  - url: https://github.com/layer3xyz
+blockchain:
+  - address: "0xF1C0dF2381Ac4a6Cac9C866DdbdE3c3D641a1337"
+    tags:
+      - eoa
+      - deployer
+    networks:
+      - optimism
+      - mainnet
+      - arbitrum
+      - scroll
+      - polygon
+      - polygon zkevm
+      - base
+      - blast
+      - mode
+      - celo
+      - gnosis
+      - zora
+      - bnb
+      - linea
+      - metis
+  - address: "0x1195Cf65f83B3A5768F3C496D3A05AD6412c64B7"
+    networks:
+      - optimism
+      - mainnet
+      - arbitrum
+      - scroll
+      - polygon
+      - polygon zkevm
+      - base
+      - blast
+      - mode
+      - celo
+      - gnosis
+      - zora
+      - bnb
+      - linea
+      - metis
+    tags:
+      - contract
+      - proxy
+    name: CUBE
+  - address: "0xF77bd7c05598E094bc06e34bB81C07Bd3B091dB1"
+    networks:
+      - zksync
+    tags:
+      - contract
+      - proxy
+    name: CUBE
+  - address: "0x1796dfBD0a0CF0e9940dd9463ee2cCf8d054E467"
+    tags:
+      - eoa
+      - deployer
+    networks:
+      - zksync
+  - address: "0x5e2b297016d41055876ff1078100c548adc3a498"
+    networks:
+      - optimism
+      - mainnet
+      - arbitrum
+      - scroll
+      - polygon
+      - polygon zkevm
+      - base
+      - blast
+      - mode
+      - celo
+      - gnosis
+      - zora
+      - bnb
+      - linea
+      - metis
+    tags:
+      - contract
+      - factory
+      - escrow


### PR DESCRIPTION
Currently all deployed contracts are in this repo, [https://github.com/layer3xyz/cubes](https://github.com/layer3xyz/cubes), but going forward we'll have more repos and I therefore think Layer3 at an org level is the correct indexing here. Please let me know if I should change anything.