### PR TITLE
fix: publish the latest schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ If you want to change the schema, you'll need to write a migration:
 3. Add the migration functions to the MIGRATIONS array in `src/migrations/index.ts`.
 4. You can run the migration by running `pnpm migrate`
 5. Make sure to commit and submit a pull request with all of the resulting changes. We will not accept any PRs where the data does not conform to the schemas.
+6. Publish a new version of the npm package. Remember to bump the version number in `package.json`. If you don't do this, you'll break all downstream dependents, because they're fetching the latest from GitHub.
 
 The framework will run migrations in sequence, so you are guaranteed that your data is valid as of the previous version.
 Note: we only currently support migrating in one direction (and not reverting)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-directory",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "description": "Open source software directory",
   "repository": {
     "type": "git",

--- a/src/fetchData.ts
+++ b/src/fetchData.ts
@@ -37,11 +37,19 @@ export async function fetchData(branchOrCommit?: string) {
 export async function loadData(basePath: string) {
   const projectFiles = await glob(path.resolve(basePath, PROJECTS_GLOB));
   const collectionFiles = await glob(path.resolve(basePath, COLLECTIONS_GLOB));
-  const projects: Project[] = await Promise.all(
-    projectFiles.map((f) => readProjectFile(f)),
-  );
-  const collections: Collection[] = await Promise.all(
-    collectionFiles.map((f) => readCollectionFile(f)),
-  );
-  return { projects, collections };
+  try {
+    const projects: Project[] = await Promise.all(
+      projectFiles.map((f) => readProjectFile(f)),
+    );
+    const collections: Collection[] = await Promise.all(
+      collectionFiles.map((f) => readCollectionFile(f)),
+    );
+    return { projects, collections };
+  } catch (e) {
+    const msg =
+      "[OSS-DIRECTORY] failed reading from GitHub. Are you sure you have the latest version of the 'oss-directory' package?";
+    console.error(msg);
+    console.error(e);
+    throw new Error(msg);
+  }
 }

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -84,10 +84,13 @@ function safeCastObject<T>(obj: any, schemaName: Schema): T {
  */
 async function readFileToObject<T>(
   filename: string,
-  format: FileFormat,
   schemaName: Schema,
+  opts: ReadOptions,
 ): Promise<T> {
-  const obj = await readFileParse(filename, format);
+  const obj = await readFileParse(filename, opts.format);
+  if (opts.skipValidation) {
+    return obj;
+  }
   return safeCastObject<T>(obj, schemaName);
 }
 
@@ -168,7 +171,8 @@ function safeCastBlockchainAddress(obj: any): BlockchainAddress {
 }
 
 type ReadOptions = {
-  format?: FileFormat;
+  format: FileFormat;
+  skipValidation: boolean;
 };
 
 /**
@@ -179,13 +183,12 @@ type ReadOptions = {
  */
 async function readProjectFile(
   filename: string,
-  opts?: ReadOptions,
+  opts?: Partial<ReadOptions>,
 ): Promise<Project> {
-  return readFileToObject<Project>(
-    filename,
-    opts?.format ?? DEFAULT_FORMAT,
-    PROJECT_SCHEMA,
-  );
+  return readFileToObject<Project>(filename, PROJECT_SCHEMA, {
+    format: opts?.format ?? DEFAULT_FORMAT,
+    skipValidation: opts?.skipValidation ?? false,
+  });
 }
 
 /**
@@ -196,13 +199,12 @@ async function readProjectFile(
  */
 async function readCollectionFile(
   filename: string,
-  opts?: ReadOptions,
+  opts?: Partial<ReadOptions>,
 ): Promise<Collection> {
-  return readFileToObject<Collection>(
-    filename,
-    opts?.format ?? DEFAULT_FORMAT,
-    COLLECTION_SCHEMA,
-  );
+  return readFileToObject<Collection>(filename, COLLECTION_SCHEMA, {
+    format: opts?.format ?? DEFAULT_FORMAT,
+    skipValidation: opts?.skipValidation || false,
+  });
 }
 
 export {


### PR DESCRIPTION
* JSON schema has changed, we need to publish with latest migration
* Added a reminder in the README for next time
* Added a pathway to skip validation when reading files, though we don't use that