### PR TITLE
Update kiwi-news-attestate.yaml

### DIFF
--- a/data/projects/k/kiwi-news-attestate.yaml
+++ b/data/projects/k/kiwi-news-attestate.yaml
@@ -1,41 +1,10 @@
 version: 7
 name: kiwi-news-attestate
 display_name: Kiwi News
-github:
-  - url: https://github.com/attestate/kiwistand
-  - url: https://github.com/attestate/awesome-kiwinews
-  - url: https://github.com/attestate/delegator2
 blockchain:
   - address: "0x66747bdc903d17c586fa09ee5d6b54cc85bbea45"
     networks:
       - optimism
     tags:
       - contract
-    name: unverified
-  - address: "0xea3b341b1f189f8e56b00c8e387b770acae121cf"
-    networks:
-      - optimism
-    tags:
-      - contract
-    name: PurchaseDelegator
-  - address: "0x08b7ecfac2c5754abafb789c84f8fa37c9f088b0"
-    networks:
-      - optimism
-    tags:
-      - contract
-    name: Delegator2
-  - address: "0x1633451ff7cd3688c944634b08829326df316dd7"
-    networks:
-      - optimism
-    tags:
-      - safe
-      - wallet
-  - address: "0xee324c588cef1bf1c1360883e4318834af66366d"
-    networks:
-      - optimism
-    tags:
-      - eoa
-      - wallet
-    name: timdaub.eth
-websites:
-  - url: https://attestate.com
+    name: Kiwi Pass NFT collection


### PR DESCRIPTION
<img width="813" alt="Screenshot 2024-05-28 at 22 42 10" src="https://github.com/opensource-observer/oss-directory/assets/2758453/a60b0be5-1e73-4337-85b5-7eb115ecbec8">

We managed to add all of our contracts, except for the Zora one. What was suggested on Discord is that the contract can be added if the user isn't a creator, which we (Kiwi News), clearly aren't

![photo_2024-05-28 22 42 45](https://github.com/opensource-observer/oss-directory/assets/2758453/f0d94e6a-6dc7-48ad-9675-32f6968a5f0e)
<img width="656" alt="Screenshot 2024-05-28 at 22 45 22" src="https://github.com/opensource-observer/oss-directory/assets/2758453/d9a0d322-5da9-458b-89af-afc70e9b845d">

