### PR TITLE
add: velodrome, aerodrome contracts

### DIFF
--- a/data/projects/a/aerodrome-finance.yaml
+++ b/data/projects/a/aerodrome-finance.yaml
@@ -3,6 +3,291 @@ name: aerodrome-finance
 display_name: Aerodrome Finance
 github:
   - url: https://github.com/aerodrome-finance
+blockchain:
+  - address: "0xE4c69af018B2EA9e575026c0472B6531A2bC382F"
+    networks:
+      - base
+    tags:
+      - contract
+    name: AirdropDistributor
+  - address: "0x940181a94A35A4569E4529A3CDfB74e38FD98631"
+    networks:
+      - base
+    tags:
+      - contract
+    name: AERO
+  - address: "0xE9992487b2EE03b7a91241695A58E0ef3654643E"
+    networks:
+      - base
+    tags:
+      - contract
+    name: ArtProxy
+  - address: "0x5C3F18F06CC09CA1910767A34a20F771039E37C0"
+    networks:
+      - base
+    tags:
+      - contract
+    name: FactoryRegistry
+  - address: "0x15e62707FCA7352fbE35F51a8D6b0F8066A05DCc"
+    networks:
+      - base
+    tags:
+      - contract
+    name: Forwarder
+  - address: "0x35f35cA5B132CaDf2916BaB57639128eAC5bbcb5"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: GaugeFactory
+  - address: "0xFdA1fb5A2a5B23638C7017950506a36dcFD2bDC3"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: ManagedRewardsFactory
+  - address: "0xeB018363F0a9Af8f91F06FEe6613a751b2A33FE5"
+    networks:
+      - base
+    tags:
+      - contract
+    name: Minter
+  - address: "0x420DD381b31aEf6683db6B902084cB0FFECe40Da"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: PoolFactory
+  - address: "0x227f65131A261548b057215bB1D5Ab2997964C7d"
+    networks:
+      - base
+    tags:
+      - contract
+    name: RewardsDistributor
+  - address: "0xcF77a3Ba9A5CA399B7c97c74d54e5b1Beb874E43"
+    networks:
+      - base
+    tags:
+      - contract
+    name: Router
+  - address: "0x16613524e02ad97eDfeF371bC883F2F5d6C480A5"
+    networks:
+      - base
+    tags:
+      - contract
+    name: Voter
+  - address: "0xeBf418Fe2512e7E6bd9b87a8F0f294aCDC67e6B4"
+    networks:
+      - base
+    tags:
+      - contract
+    name: VotingEscrow
+  - address: "0x45cA74858C579E717ee29A86042E0d53B252B504"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: VotingRewardsFactory
+  - address: "0xD30677bd8dd15132F251Cb54CbDA552d2A05Fb08"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: CLGaugeFactory
+  - address: "0xF5601F95708256A118EF5971820327F362442D2d"
+    networks:
+      - base
+    tags:
+      - contract
+    name: CLGauge
+  - address: "0x0A5aA5D3a4d28014f967Bf0f29EAA3FF9807D5c6"
+    networks:
+      - base
+    tags:
+      - contract
+    name: MixedQuoter
+  - address: "0x827922686190790b37229fd06084350E74485b72"
+    networks:
+      - base
+    tags:
+      - contract
+    name: NonfungiblePositionManager
+  - address: "0x01b0CaCB9A8004e08D075c919B5dF3b59FD53c55"
+    networks:
+      - base
+    tags:
+      - contract
+    name: NonfungibleTokenPositionDescriptor
+  - address: "0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: CLPoolFactory
+  - address: "0xeC8E5342B19977B4eF8892e02D8DAEcfa1315831"
+    networks:
+      - base
+    tags:
+      - contract
+    name: CLPool
+  - address: "0x254cF9E1E6e233aa1AC962CB9B05b2cfeAaE15b0"
+    networks:
+      - base
+    tags:
+      - contract
+    name: Quoter
+  - address: "0xF4171B0953b52Fa55462E4d76ecA1845Db69af00"
+    networks:
+      - base
+    tags:
+      - contract
+    name: SwapFeeModule
+  - address: "0x0AD08370c76Ff426F534bb2AFFD9b5555338ee68"
+    networks:
+      - base
+    tags:
+      - contract
+    name: UnstakedFeeModule
+  - address: "0x6Cb442acF35158D5eDa88fe602221b67B400Be3E"
+    networks:
+      - base
+    tags:
+      - contract
+    name: UniversalRouter
+  - address: "0x0AD09A66af0154a84e86F761313d02d0abB6edd5"
+    networks:
+      - base
+    tags:
+      - contract
+    name: SlipstreamHelper
+  - address: "0x3e703fd2B6506e2Abcce2C8B5633872a7D9B6FbC"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: OldCLGaugeFactory
+  - address: "0xb4318C490E1bd4C0c01A8F0E3dF26A28B1136F48"
+    networks:
+      - base
+    tags:
+      - contract
+    name: OldCLGauge
+  - address: "0xE2af5FdE219B4c6047AAEc44444f120675b406E2"
+    networks:
+      - base
+    tags:
+      - contract
+    name: OldMixedQuoter
+  - address: "0xc741beb2156827704A1466575ccA1cBf726a1178"
+    networks:
+      - base
+    tags:
+      - contract
+    name: OldNonfungiblePositionManager
+  - address: "0xf1503A3AB542618dcCD3Cac1C69C46fA28A040ed"
+    networks:
+      - base
+    tags:
+      - contract
+    name: OldNonfungibleTokenPositionDescriptor
+  - address: "0x9592CD9B267748cbfBDe90Ac9F7DF3c437A6d51B"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: OldCLPoolFactory
+  - address: "0xF926b5acC092E396A3b337642Be2E4cAe3f5da8E"
+    networks:
+      - base
+    tags:
+      - contract
+    name: OldCLPool
+  - address: "0xBe0EC710C44B75c34534690C01C22AC0609762D7"
+    networks:
+      - base
+    tags:
+      - contract
+    name: OldQuoter
+  - address: "0xfDDfA16D30acaA02D5C57324C4285a914cc5aF6c"
+    networks:
+      - base
+    tags:
+      - contract
+    name: OldSwapFeeModule
+  - address: "0x3a0a75038aF395042F477911D50e3079b588862c"
+    networks:
+      - base
+    tags:
+      - contract
+    name: OldUnstakedFeeModule
+  - address: "0xf07835bbf6eea0d05392Fb4d3B9e5a333Ca4da2A"
+    networks:
+      - base
+    tags:
+      - contract
+    name: OldUniversalRouter
+  - address: "0x825223F246C98A0BA2b05a90701C9Db5810831f2"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: AutoCompounderFactory
+  - address: "0x1c4a5522E293d15168a19baC5319448f58F3dfBA"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: AutoConverterFactory
+  - address: "0xB953839a8361840f454e7F2A891AD7e13608f2fc"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: AutoCompounderFactory
+  - address: "0xd2823278643ed905FF8477Ef0bB9c89E7B0BA651"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: AutoConverterFactory
+  - address: "0xD36dAb3bEf6DD077bC4D59098d03fF1053e17397"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: AutoCompounderFactory
+  - address: "0xb805fca66277ACFC45DCBBAC0F770588F2B3a223"
+    networks:
+      - base
+    tags:
+      - contract
+      - factory
+    name: AutoConverterFactory
+  - address: "0x05e41604B9463e2224227053980dfF3f57fb6dB5"
+    networks:
+      - base
+    tags:
+      - contract
+    name: RelayFactoryRegistry
+  - address: "0xD308aBCe663302d3b86b36d332CEFd8A4F62C5Ed"
+    networks:
+      - base
+    tags:
+      - contract
+    name: RelayFactoryRegistry
 websites:
   - url: https://aerodrome.finance
 description: The trading and liquidity marketplace on Base network

--- a/data/projects/v/velodrome.yaml
+++ b/data/projects/v/velodrome.yaml
@@ -348,6 +348,266 @@ blockchain:
       - eoa
       - wallet
     name: aerodromefinance.eth
+  - address: "0x987E7922367B23C4A5fa34C8C5B1385174A095d6"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: GaugeSinkDrain
+  - address: "0x9560e827aF36c94D2Ac33a39bCE1Fe78631088Db"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: VELOv2
+  - address: "0x41C914ee0c7E1A5edCD0295623e6dC557B5aBf3C"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: Voter
+  - address: "0x6b1253B116B5919932399295C75116d33F8EfF96"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: RelayFactoryRegistry
+  - address: "0x7bC95b327DF9d6dE05C1A02F6D252986Fcf45AF7"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: KeeperRegistry
+  - address: "0x7feF5407eD6C83f78eF82B3389FF89019095266B"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: OptimizerRegistry
+  - address: "0x8831DD83f24094862fBfa9bbbE2690088c3C8320"
+    networks:
+      - optimism
+      - factory
+    tags:
+      - contract
+    name: AutoCompounderFactory
+  - address: "0x12419cfe11E85e3E28927eC84209cD7a4CfeCaB1"
+    networks:
+      - optimism
+      - factory
+    tags:
+      - contract
+    name: AutoConverterFactory
+  - address: "0xA7B6243912FB3D752de29B1ec842f3B3313cE148"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: Optimizer
+  - address: "0x282AC0eA96493650F1A5E5e5d20490C782F1592a"
+    networks:
+      - optimism
+    tags:
+      - contract
+      - factory
+    name: CLGaugeFactory
+  - address: "0x6D600CC5F14B81665606Ca1985605464BA332Bad"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: CLGauge
+  - address: "0xa4ac92a0F54f1a447c55a4082c90742F5E76Df62"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: MixedQuoter
+  - address: "0xbB5DFE1380333CEE4c2EeBd7202c80dE2256AdF4"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: NonfungiblePositionManager
+  - address: "0x2c998811b2Af32416C8ff4c0ea85f0e7Ed834ff8"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: NonfungibleTokenPositionDescriptor
+  - address: "0x548118C7E0B865C2CfA94D15EC86B666468ac758"
+    networks:
+      - optimism
+    tags:
+      - contract
+      - factory
+    name: CLPoolFactory
+  - address: "0xE0A596c403E854FFb9C828aB4f07eEae04A05D37"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: CLPool
+  - address: "0xA2DEcF05c16537C702779083Fe067e308463CE45"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: Quoter
+  - address: "0xA9c319945f706dd1809819321a2e31C9A169e9c1"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: SwapFeeModule
+  - address: "0x5A993209065ea74b50E23a378ddB7068189345D0"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: UnstakedFeeModule
+  - address: "0xF132bdb9573867cD72f2585C338B923F973EB817"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: UniversalRouter
+  - address: "0x495193DaebdE03E12857f4d3BB8984da2d447a69"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: SlipstreamHelper
+  - address: "0x25CbdDb98b35ab1FF77413456B31EC81A6B6B746"
+    networks:
+      - optimism
+    tags:
+      - contract
+      - factory
+    name: PairFactory
+  - address: "0xA84EA94Aa705F7d009CDDF2a60f65c0d446b748E"
+    networks:
+      - optimism
+    tags:
+      - contract
+      - factory
+    name: BribeFactory
+  - address: "0xC5be2c918EB04B091962fDF095A217A55CFA42C5"
+    networks:
+      - optimism
+    tags:
+      - contract
+      - factory
+    name: GaugeFactory
+  - address: "0x5d5Bea9f0Fc13d967511668a60a3369fD53F784F"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: RewardsDistributor
+  - address: "0x3460Dc71A8863710D1C907B8d9D5DBC053a4102d"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: Minter
+  - address: "0xe9F00f2e61CB0c6fb00A2e457546aCbF0fC303C2"
+    networks:
+      - optimism
+    tags:
+      - contract
+    name: RelayFactoryRegistry
+  - address: "0x103935f12063c1AbCe28Aa322EFE9eA9bc63ca71"
+    networks:
+      - optimism
+    tags:
+      - contract
+      - factory
+    name: AutoCompounderFactory
+  - address: "0x87E658fa1C67014826A69EFdccDfEFFf19E34B30"
+    networks:
+      - optimism
+    tags:
+      - contract
+      - factory
+    name: AutoConverterFactory
+  - address: "0xd4B332F2ADe5C2c1043138116164Eb058C437db9"
+    networks:
+      - optimism
+    tags:
+      - contract
+      - factory
+    name: AutoCompounderFactory
+  - address: "0x77bD18662B4DD6D2523653b145c978Ef1Bc5bc1b"
+    networks:
+      - optimism
+    tags:
+      - contract
+      - factory
+    name: AutoConverterFactory
+  - address: "0x3a63171DD9BebF4D07BC782FECC7eb0b890C2A45"
+    networks:
+      - any_evm
+    tags:
+      - contract
+    name: Router
+  - address: "0x31832f2a97Fd20664D76Cc421207669b55CE4BC0"
+    networks:
+      - any_evm
+    tags:
+      - contract
+      - factory
+    name: PoolFactory
+  - address: "0x52DCddAFdD31bcD44881F6591A97dA1fF5808891"
+    networks:
+      - mode
+    tags:
+      - contract
+    name: Quoter
+  - address: "0xD2F998a46e4d9Dd57aF1a28EBa8C34E7dD3851D7"
+    networks:
+      - mode
+    tags:
+      - contract
+      - factory
+    name: ModeStakingRewardsFactory
+  - address: "0x8d9c67488c154286b9d4ccac6c4cbf30589107a7"
+    networks:
+      - any_evm
+    tags:
+      - contract
+    name: TokenRegistry
+  - address: "0x29EC19fA20db90BeD7F813298C45A4f4cD90eE18"
+    networks:
+      - mode
+    tags:
+      - contract
+    name: ModeUniversalRouter
+  - address: "0x0f3887909C548C41Eb8a6667a4B23FC6683EF8ba"
+    networks:
+      - any_evm
+    tags:
+      - contract
+    name: Quoter
+  - address: "0x8Eb6838B4e998DA08aab851F3d42076f21530389"
+    networks:
+      - any_evm
+    tags:
+      - contract
+      - factory
+    name: StakingRewardsFactory
+  - address: "0x593d092bb28ccefe33bfdd3d9457e77bd3084271"
+    networks:
+      - any_evm
+    tags:
+      - contract
+    name: StakingRewards
+  - address: "0xc3F14F34EA43943e6fd677A2BDceA65882e67783"
+    networks:
+      - any_evm
+    tags:
+      - contract
+    name: UniversalRouter
 websites:
   - url: https://velodrome.finance
 description: The trading and liquidity marketplace on Superchain

--- a/data/projects/v/velodrome.yaml
+++ b/data/projects/v/velodrome.yaml
@@ -387,16 +387,16 @@ blockchain:
   - address: "0x8831DD83f24094862fBfa9bbbE2690088c3C8320"
     networks:
       - optimism
-      - factory
     tags:
       - contract
+      - factory
     name: AutoCompounderFactory
   - address: "0x12419cfe11E85e3E28927eC84209cD7a4CfeCaB1"
     networks:
       - optimism
-      - factory
     tags:
       - contract
+      - factory
     name: AutoConverterFactory
   - address: "0xA7B6243912FB3D752de29B1ec842f3B3313cE148"
     networks:


### PR DESCRIPTION
Adding Velodrome and Aerodrome contracts

`any_evm` was used for contracts deployed to BOB chain. Please lmk if I should remove those contracts