### PR TITLE
Add ACI deployers to aave addresses list

### DIFF
--- a/data/projects/a/aave.yaml
+++ b/data/projects/a/aave.yaml
@@ -795,6 +795,24 @@ blockchain:
     tags:
       - contract
     name: DefaultReserveInterestRateStrategy
+  - address: "0x57ab7ee15cE5ECacB1aB84EE42D5A9d0d8112922"
+    networks:
+      - any_evm
+    tags:
+      - eoa
+      - deployer
+  - address: "0x329c54289Ff5D6B7b7daE13592C6B1EDA1543eD4"
+    networks:
+      - any_evm
+    tags:
+      - eoa
+      - deployer
+  - address: "0x3Cbded22F878aFC8d39dCD744d3Fe62086B76193"
+    networks:
+      - any_evm
+    tags:
+      - eoa
+      - deployer
 websites:
   - url: http://aave.com
 description: Building the future of DeFi.


### PR DESCRIPTION
Add the deployer addresses of the ACI (Aave Chan Initiative) to `aave.yaml`:
- [0x57ab7ee15cE5ECacB1aB84EE42D5A9d0d8112922](https://etherscan.io/address/0x57ab7ee15cE5ECacB1aB84EE42D5A9d0d8112922): deployer 22
- [0x329c54289Ff5D6B7b7daE13592C6B1EDA1543eD4](https://etherscan.io/address/0x329c54289Ff5D6B7b7daE13592C6B1EDA1543eD4): deployer 13
- [0x3Cbded22F878aFC8d39dCD744d3Fe62086B76193](https://etherscan.io/address/0x3Cbded22F878aFC8d39dCD744d3Fe62086B76193): deployer 21