### PR TITLE
fix: remove multicall and create2 from CMT

### DIFF
--- a/data/projects/c/createmytoken.yaml
+++ b/data/projects/c/createmytoken.yaml
@@ -45,3 +45,10 @@ blockchain:
       - base
     tags:
       - contract
+  - address: "0x0000000000FFe8B47B3e2130213B802212439497"
+    networks:
+      - base
+      - optimism
+    tags:
+      - contract
+      - factory

--- a/data/projects/c/createmytoken.yaml
+++ b/data/projects/c/createmytoken.yaml
@@ -45,16 +45,3 @@ blockchain:
       - base
     tags:
       - contract
-  - address: "0x0000000000FFe8B47B3e2130213B802212439497"
-    networks:
-      - base
-      - optimism
-    tags:
-      - contract
-      - factory
-  - address: "0xcA11bde05977b3631167028862bE2a173976CA11"
-    networks:
-      - base
-      - optimism
-    tags:
-      - contract


### PR DESCRIPTION
@akshatmittal I have run some tests on the production data and am now seeing the issue you alerted me to in your initial PR #332 

Unfortunately, we won't be able to attribute the downstream impact of these deployments to CMT. The attribution requirements for this round are very strict: all impact goes to the owner of the deployer. 

FWIW, this requirement has caused some disappointment with other use cases 😞  (eg, apps that facilitate P2P transactions, interactions with zora factories, etc)

In any case, I have kept the other deployments you included, but removed the multicall and create2 contracts from the CMT project file. 