### PR TITLE
Update Harvest contracts

### DIFF
--- a/data/projects/h/harvestfi.yaml
+++ b/data/projects/h/harvestfi.yaml
@@ -15,3 +15,813 @@ blockchain:
       - deployer
     networks:
       - any_evm
+  - address: "0x50c6c553d083232F1994175332Ff5508b81Aeb96"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xAb0a63eE480E02Ad0d9210ffFae0CFC3Ced7c98B"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x99f5b2039768100d2Ef2484d52E1ca3889649b4D"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x8f61C658c5960962e6D108F0f63133F248F6d721"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x16Df1C008D1a2aCF511ea7A2e6eF06dC54Cd9f14"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x4C8d67201DCED0A8E44F59d419Cb74665b4cdE55"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x080af038a0f1C8961bc21f108Af23932EDE63190"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x127dc157aF74858b36bcca07D5A02ef27Cd442d0"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xcf58a2fEc96fFDF11B0dFA1ed15433b488485cf3"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xc7548d8D7560f6679e369d0556C44Fe1EDdea3E9"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xB41c68ae552b06eF0d0402f20B133FbdA8e1B143"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xBC8b2b8a54bDCfd8CA924b1826565823c897A2a9"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe3E2937327419ea5EaF032bF25E880199cE3DE3C"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x68f5992eE86879871cA40A7342406d6F6B5a6861"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x32938237AC6212957061917E74Dd2Ab4956Bd2ED"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x60aFd9E8BE2f14C259323056850F9eC0d1804879"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xa59Ece46E227fc5EaBB851D490D99C7b2EfC4185"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xAe6F5f28463FB7A872f06aC8ABFAFFD56bb13F89"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x37e6FAcfFF094E108A424926ed54d33EAEF8a20C"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x6B93e34d33d9188C01F02e7c19E941f7b8E338fc"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x202d29a1749aA6F7D06d3982082133EBd83F45c5"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x4423A763D4804ead6FE1faa9A2D0756B25347C47"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x492A07E2f2BD6a85597052f6497aC830DA0a5f63"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x1ED95B71B000a7258bfb2f99E41d2dD57817E5CF"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x9bCf13aFfc360736f19141E480f9eCC157A501BC"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xDF83a4f815d898b7044f227e561E3CFbBC1C21cF"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x99946CEFb02249270373f7F2DC0bd9b085d52ae5"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x6a149EBe60f157C64cA731c1D67C2b8c547bf872"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xc4F28CAE78550b4d85d6F928805483cEE3bcB3E5"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x90613e167D42CA420942082157B42AF6fc6a8087"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x0B0193fAD49DE45F5E2B0A9f5D6Bc3BB7D281688"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe4985bFa5baAD80f8b56ebF68fC2ea30BaB59Da0"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xde60B582c211dE3199B7e4a8336F49CDa67dEAec"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x3C31127457C6D8ae0E943A17f2507B2c11C28726"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x3070304158fBAACbcD9625C4698837A4090AC157"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xd81E055E85b6300b647b4f4F80Ea68012A9180BB"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x24d6571B99EB2009DEf501D3b3ad167BCC5bd304"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x40455352Dd3c5D65A40729C22B12265C17B37b75"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x3ef3a16367A82436cE64b25907db3dC58664A727"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x6C90F6cC42cC64d6fC110f02dE964089b6298dE7"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xE82E813339EEE960Aa4d87d43241cc27Db9dd916"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x21B27a241E361F6C4d430FD120B2651A89DCc942"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xA066b2126f25C0237c0DdB293DB452597B1E0241"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xabD5D3c1532B171Ef83b25318624d1e0143B14cE"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xC62e0378bb3736bcC148B9A25b1e2ACF523B5f00"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x94012F721e059748B986394EB5fE2820025F47Ff"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x073aDE312d3c422d43B20311F3Ef0e83E8E1AC1a"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x47e3daF382C4603450905fb68766DB8308315407"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xE97a32D05952357C7b5D4EafC70197a0B834f0F7"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x8d44eEdB4074E02bd418286b4Af5bD5E47F91A6f"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x94aA414BefB207B869904f3310665A63fBA3AE50"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x8b99389DdF99d429b2C5b8AB004A60397a734A5c"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x86d609d98FDc11D6f45829dE0354010d636adf19"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x284c60490212DB0dc0b8F93503d35744f8053381"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x3D045A708a3cbf931e0615bEaD81ef7B50E80A48"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x366500b48B33923fd0Cdc5cb65F241D1D9366623"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x1E55620cAB52B5CD5dA05C4b3353A4a0AD681Eb1"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x2466858294Cd1B9e6769D55B2473fEAc26aba98e"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xc240B0d6d9dbFE837ee0E072b2fba8B02c62c238"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe98A6cD142b898647e1d9D14686De6c7f8088774"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xC64124c53821ad1AD3EF2b5ed986884c7b9eB728"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe3C8B0Fc0936Fee797873011ddd0D3a70E6Fc7AC"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x4B0A8DFd3bBEEab835E8B5Dc453822490A93c32e"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xE155314952b3190E37e89e472e62112D2661551b"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x381ef1c1e59Cf7D3356660C660aE0d2BA9662fb3"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xd7Fb547032601eCFA483dC2491Da4C2Cfe378D65"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x6cb475E29D7d71050684aDB20EBBb93d6556852f"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x6bf2726C111E8530Da099ed64850103B6Cb0b535"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xed3088c1f2cdE063Ef3EB7D1E2164747d80456cF"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xb4afAF87EA0C27819f371d20A64d93eeFc439aC7"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x24Eff2133a9Ae99E591D4ecB4e7DF037E3d4f45F"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x19C7881d02cb1A09DAAD0407963B42ef42276027"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x4C967a2A63106Cd68dF56DeBEdf6f2680A475e79"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe3F359b47dFb4431487336b6Fe595608607794D8"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xBAC674E5B91281D2eEae2832d6647ACf341BB8C3"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xE139ecB031b6877645f5198e43b3F1CF9E594957"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xaEAACE6fB52faCa7B973Fe3f634F844BB39f0694"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xb993100108d20D0FFb43dAf1b6a98f13a5721EBF"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x80EE6D47847EEd1AbAe41C30CE6Df9b116E90CA3"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x071aE42BEC0481AEf329B401d2cd32A9a2aB3Ee7"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x6a021efA7467078d2b30e07502832DB842B0a42A"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xbecA2C0888a8c79698aCFd4D76977F16C426CdF4"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xeD05b21b403543255d262eADD928f4bF1710c6a1"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x3169Cbd868851570D246CCbEF8209B64d07E5268"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x2E602943C0a1B1027B2AC998facB698fD4F689A7"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe3A230Eef4D0551C96C6Acf0000f7A5B93799ADf"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xbbf4c2cd1c9588587d5E182a03273F29E238Fe58"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xce9e31f1Ea12c2bF7F8d5DAc920a6C8852bbf1bf"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xDa7655F9a789446b963c591559B4a2967Cc0DBF6"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x44d5DF4aD241044330B8ec04404bEAf8A0c1d2eF"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x35fD1bb2676C3E12cA6e9B018FFCC89AE92CF2c8"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xa36fa89A9133b1974Efb5206e24F1A9d49a31319"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x57e46d910933cb3d84d6c44a93cbb503A5136265"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xA9Da08B43E7B650527CE6254E0efBB26fba7D928"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x48AF70F0E97cEfdad20F0E4360eE2B27021C767a"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x39E3361eC4441a714b5089d5054A269f9AeDBEC9"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xDAC20e1e4bB33f5732D23Aac0cBe84E23D9fF20d"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x40cE8f857DDB40f6bEAFd237E7894cB08e2fB447"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x9b02DCB475510B87B09abea883C07Cf9Ec44271D"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe948E9c99CFDe4c5A480B4e58C8CB4fC5CA7bF2c"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x1DC42246E913725eA2d4E1858b36c85C314eAdD1"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xf4CaDf3A558C312dE522A258FeDfB41fC09723Cb"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xc0d3ccD19D8b3a159c55268ac8a9c4b13f7c1146"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xDb08f5E56a00A1409053E31dbDae04fF643D8Cde"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe03481E68FC15197C17EDD3B9F38b3cc821f7446"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x7812026Df9aB72b202BB1f2ae47dC377A0B16b20"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x5501bE44327E2B02da51DC0e832be40675016479"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x28f914229770e403cEB2Ae55069fF7447247470a"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xEA73d5C5496E5d310Fb6f2e415A0505a6c90A01e"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x2b0A02C9c78702b871a64fD7E437F3F200b7F2a5"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xC08F9EcfD9b43e3fF8284bC4FfCa71F375b36055"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xDa4fb2300C9d80F14ff815193ee0f0810B79E3Ce"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x44F91D53AED974B99F5A1c183f96C8E4F99E524d"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x79d906B0Bd752a7C366A096AA4915b91C79547FE"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x350A56d7d5eA460D249D6852a95E5d2044B8436e"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x1c2045ede183BD64bf67475b33d2a544a8de1a2d"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x8EAbe374666441d6373D8bE0478aB2F4E04DDAa5"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x69A3b1F2e133715282009be67d98BEb9247d0Bd5"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x27cB5897E2a6963935EADd919308c25Cee2CbEB7"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x36Ad5cc377a22436bbdc1084aF37BDa96daDD8cb"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x60794DA3088c2ca731833F9F5C39dC3a8eCC785A"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe70cb31b7DF428655Cec64921a6BEa5780710A37"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x8aDa0EFD2bf2C2A12e4A7151fFf0b433bda69bE0"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x93f40d78caf881F3F827150d26F3fDaCb4863CB9"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xD8a460fB996C651754972421dA7A0c971949E436"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xb30EAD2fACcd5dff5921f16fC470F436aD9cEabe"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x1ABB720436eE6A0f066B00019FDBC0C5d66a0728"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x89C6FBCb0CBeb317EBE2C53fd51F99cE351981BD"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x64Ff0f8fadFD73c62C83e1468E3A834e61B5345E"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x0a72c47E310380528269D6039cFfd8a7372E1c1f"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x22819ABfFeBfdD2ffF1a147741440068ca63Af33"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x04Cc681D9204BB02a4047a2D324108634F03056b"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x40C163464eeD09421f14789DBAd14D516B95fF77"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x74bAE5a2BC59B974Bc1F5b9Ff09c23aFc6564F1C"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x43FE585E9B52ba622a184aE07810213Da869496E"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x8323824d05620244238d6053f148409d9dcCBcb7"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xEf1c16bd57418382b33aEa88E713Dc1390ecC457"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe860CC946338769bC60D68eC9576A3A258c7D156"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x2696E8017A422af7ee764Fa598C7AC3B75007FdB"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x3A3E0Dfe3b73f8cf90a4Ee2D72621886080aa628"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x55b2Ea6709B09356Ed2f5f14C514b4896411D873"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xbF5Ff797679cAae7EEeaF7cc62bEdC660988Ed0b"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x55Df86C1874D2D216bAF3b5CB0d7a54Fc36CB1ae"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x1823BA461474eb1b7D4FC616De2BE16096797c78"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x65097888f7806e0f1912B5A077e46EA6297eA5DA"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xe8EA847d87faE07f4F31535b72F1772d468cfb7b"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xb8443907963f708d8d44369B3e5AAA42F8eF078c"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x7d57Cd133785ba497c1D0259D7b3AF5334418735"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x241848754B3316f3ce3335bA1e823e245794DA4f"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x70194e67E050553F83dF46FD18996bA0F63Fe13A"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x406DDBd559a99d7b1c172203Dc11e760f6b13E31"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x721514c2cAac28E482A0A281C3D7f41b3988A1E1"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x47a74c92878e436dfedA2C17610DaCed19f885e9"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xF6365545e263Fb36E78F792d1212106440A04469"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x20Aa62AC787D2f7556c8d48e43eD15E0081B672C"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xb93201d8B3C221f14032ADE6314ac9E458300254"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x18190885B6B8F684fd3de366c0A439eaf36a4D0A"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x0FBeA24A65b7089A9EE705f32EdD0A793A89f75b"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x96328405a3281bf7dFC46B4Ac1119e6D542b0cD9"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x39be71b2Cd3E927EE84684767f81dAb3ab6A2116"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0x77Ac8D44F393aE99d392d495B2165e4f3Cb8823D"
+    tags:
+      - contract
+    networks:
+      - base
+  - address: "0xF1A26a78da5FA19E55C95DF13e1af9Aa289F1A5a"
+    tags:
+      - contract
+    networks:
+      - base


### PR DESCRIPTION
Many of the contracts deployed by Harvest Finance do not get automatically registered through the deployer address. I have now added them manually.

Here are some examples of such a contracts: 
- vault: https://basescan.org/address/0x0b0193fad49de45f5e2b0a9f5d6bc3bb7d281688
- strategy: https://basescan.org/address/0x525779bB64FFf50BB0c04F017DDd442C364fF4A6
- staking pool: https://basescan.org/address/0x2e602943c0a1b1027b2ac998facb698fd4f689a7

All three of these get deployed through our [MegaFactory](https://basescan.org/address/0x11cb7eda79c3b5f55b2bb501eb0cf2d605259cf3) here: https://basescan.org/tx/0x629f38f5e7570f34f8fac01e8100d009934b59e1ea2f7053e23e085479f9313c

Basescan does show our deployer account (0x6a74649aCFD7822ae8Fb78463a9f2192752E5Aa2) as the deployer for all these contracts, but it seems this is not automatically recognised by your system. This is the issue I faced in the Retro Funding application:

![image](https://github.com/opensource-observer/oss-directory/assets/34768229/16b572fa-32c5-4006-91f6-7dbad4555dec)

It is important for us that our contracts are recognised so our metrics are calculated correctly. Could you merge this PR, or let me know if there is anything else we need to do to make that happen? Thank you very much for your help!
