### PR TITLE
add: open collective top `10` projects

### DIFF
--- a/data/collections/open-collective.yaml
+++ b/data/collections/open-collective.yaml
@@ -1,0 +1,14 @@
+version: 7
+name: open-collective
+display_name: Open Collective
+projects:
+  - open-web-docs
+  - webpack
+  - babel
+  - julia-lang
+  - eslint
+  - pandas
+  - facebook-oss
+  - numpy
+  - homebrew
+  - pnpm

--- a/data/projects/b/babel.yaml
+++ b/data/projects/b/babel.yaml
@@ -1,0 +1,24 @@
+version: 7
+name: babel
+display_name: Babel
+websites:
+  - url: https://babeljs.io
+social:
+  twitter:
+    - url: https://x.com/babeljs
+github:
+  - url: https://github.com/babel
+npm:
+  - url: https://www.npmjs.com/package/@babel/core
+  - url: https://www.npmjs.com/package/@babel/runtime
+  - url: https://www.npmjs.com/package/@babel/types
+  - url: https://www.npmjs.com/package/@babel/parser
+  - url: https://www.npmjs.com/package/@babel/preset-env
+  - url: https://www.npmjs.com/package/@babel/traverse
+  - url: https://www.npmjs.com/package/@babel/generator
+  - url: https://www.npmjs.com/package/@babel/code-frame
+  - url: https://www.npmjs.com/package/@babel/preset-react
+  - url: https://www.npmjs.com/package/@babel/template
+  - url: https://www.npmjs.com/package/@babel/preset-typescript
+open_collective:
+  - url: https://opencollective.com/babel

--- a/data/projects/e/eslint.yaml
+++ b/data/projects/e/eslint.yaml
@@ -1,0 +1,24 @@
+version: 7
+name: eslint
+display_name: ESLint
+websites:
+  - url: https://eslint.org
+social:
+  twitter:
+    - url: https://x.com/geteslint
+github:
+  - url: https://github.com/eslint
+npm:
+  - url: https://www.npmjs.com/package/eslint
+  - url: https://www.npmjs.com/package/@eslint/js
+  - url: https://www.npmjs.com/package/@eslint/eslintrc
+  - url: https://www.npmjs.com/package/@eslint/config-array
+  - url: https://www.npmjs.com/package/@eslint/object-schema
+  - url: https://www.npmjs.com/package/@eslint/compat
+  - url: https://www.npmjs.com/package/@eslint/plugin-kit
+  - url: https://www.npmjs.com/package/@eslint/config-inspector
+  - url: https://www.npmjs.com/package/@eslint/core
+  - url: https://www.npmjs.com/package/@eslint/json
+  - url: https://www.npmjs.com/package/@eslint/migrate-config
+open_collective:
+  - url: https://opencollective.com/eslint

--- a/data/projects/f/facebook-oss.yaml
+++ b/data/projects/f/facebook-oss.yaml
@@ -1,0 +1,25 @@
+version: 7
+name: facebook-oss
+display_name: Facebook Open Source
+websites:
+  - url: https://opensource.fb.com
+social:
+  twitter:
+    - url: https://x.com/MetaOpenSource
+github:
+  - url: https://github.com/facebook
+npm:
+  - url: https://www.npmjs.com/package/react-strict-dom
+  - url: https://www.npmjs.com/package/react
+  - url: https://www.npmjs.com/package/metro
+  - url: https://www.npmjs.com/package/docusaurus
+  - url: https://www.npmjs.com/package/jscodeshift
+  - url: https://www.npmjs.com/package/fbt
+  - url: https://www.npmjs.com/package/facebook-nodejs-business-sdk
+  - url: https://www.npmjs.com/package/memlab
+  - url: https://www.npmjs.com/package/create-react-app
+  - url: https://www.npmjs.com/package/prop-types
+  - url: https://www.npmjs.com/package/idx
+  - url: https://www.npmjs.com/package/react-router-3
+open_collective:
+  - url: https://opencollective.com/fbopensource

--- a/data/projects/h/homebrew.yaml
+++ b/data/projects/h/homebrew.yaml
@@ -1,0 +1,12 @@
+version: 7
+name: homebrew
+display_name: Homebrew
+websites:
+  - url: https://brew.sh
+social:
+  twitter:
+    - url: https://x.com/MacHomebrew
+github:
+  - url: https://github.com/Homebrew
+open_collective:
+  - url: https://opencollective.com/homebrew

--- a/data/projects/j/julia-lang.yaml
+++ b/data/projects/j/julia-lang.yaml
@@ -1,0 +1,12 @@
+version: 7
+name: julia-lang
+display_name: Julia Programming Language
+websites:
+  - url: https://julialang.org
+social:
+  twitter:
+    - url: https://x.com/JuliaLanguage
+github:
+  - url: https://github.com/JuliaLang
+open_collective:
+  - url: https://opencollective.com/julialang

--- a/data/projects/n/numpy.yaml
+++ b/data/projects/n/numpy.yaml
@@ -1,0 +1,12 @@
+version: 7
+name: numpy
+display_name: NumPy
+websites:
+  - url: https://numpy.org
+social:
+  twitter:
+    - url: https://x.com/numpy_team
+github:
+  - url: https://github.com/numpy
+open_collective:
+  - url: https://opencollective.com/numpy

--- a/data/projects/o/open-web-docs.yaml
+++ b/data/projects/o/open-web-docs.yaml
@@ -1,0 +1,12 @@
+version: 7
+name: open-web-docs
+display_name: Open Web Docs
+websites:
+  - url: https://openwebdocs.org
+social:
+  twitter:
+    - url: https://x.com/openwebdocs
+github:
+  - url: https://github.com/openwebdocs
+open_collective:
+  - url: https://opencollective.com/open-web-docs

--- a/data/projects/p/pandas.yaml
+++ b/data/projects/p/pandas.yaml
@@ -1,0 +1,14 @@
+version: 7
+name: pandas
+display_name: pandas
+websites:
+  - url: https://pandas.pydata.org
+social:
+  twitter:
+    - url: https://x.com/pandas_dev
+  telegram:
+    - url: https://t.me/s/pandas_dev
+github:
+  - url: https://github.com/pandas-dev
+open_collective:
+  - url: https://opencollective.com/pandas

--- a/data/projects/p/pnpm.yaml
+++ b/data/projects/p/pnpm.yaml
@@ -1,0 +1,24 @@
+version: 7
+name: pnpm
+display_name: pnpm
+websites:
+  - url: https://pnpm.io
+social:
+  twitter:
+    - url: https://x.com/pnpmjs
+github:
+  - url: https://github.com/pnpm
+npm:
+  - url: https://www.npmjs.com/package/pnpm
+  - url: https://www.npmjs.com/package/find-packages
+  - url: https://www.npmjs.com/package/pkgs-graph
+  - url: https://www.npmjs.com/package/dependencies-hierarchy
+  - url: https://www.npmjs.com/package/dependency-path
+  - url: https://www.npmjs.com/package/@pnpm/self-installer
+  - url: https://www.npmjs.com/package/@pnpm/types
+  - url: https://www.npmjs.com/package/@pnpm/logger
+  - url: https://www.npmjs.com/package/@pnpm/npm-resolver
+  - url: https://www.npmjs.com/package/@pnpm/git-resolver
+
+open_collective:
+  - url: https://opencollective.com/pnpm

--- a/data/projects/w/webpack.yaml
+++ b/data/projects/w/webpack.yaml
@@ -1,0 +1,21 @@
+version: 7
+name: webpack
+display_name: Webpack
+websites:
+  - url: https://webpack.js.org
+social:
+  twitter:
+    - url: https://x.com/webpack
+  medium:
+    - url: https://medium.com/webpack
+github:
+  - url: https://github.com/webpack
+npm:
+  - url: https://www.npmjs.com/package/webpack
+  - url: https://www.npmjs.com/package/webpack-cli
+  - url: https://www.npmjs.com/package/webpack-dev-server
+  - url: https://www.npmjs.com/package/webpack-dev-middleware
+  - url: https://www.npmjs.com/package/watchpack
+  - url: https://www.npmjs.com/package/fastparse
+open_collective:
+  - url: https://opencollective.com/webpack

--- a/src/resources/schema/project.json
+++ b/src/resources/schema/project.json
@@ -37,6 +37,12 @@
         "$ref": "url.json#"
       }
     },
+    "open_collective": {
+      "type": "array",
+      "items": {
+        "$ref": "url.json#"
+      }
+    },
     "blockchain": {
       "type": "array",
       "items": {


### PR DESCRIPTION
This PR introduces data for the ten most notable (entirely subjective) Open Source Software projects in Open Collective. It also adds an `open_collective` field for projects within the project schema. This is part of https://github.com/opensource-observer/oso/issues/2200.

