### PR TITLE
fix: update `workflow` permissions

### DIFF
--- a/.github/workflows/external-prs-handle-comment.yml
+++ b/.github/workflows/external-prs-handle-comment.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # This job only runs for pull request comments
-    if: github.event.issue.pull_request && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
+    if: github.event.issue.pull_request
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,10 +29,17 @@ jobs:
       - name: Setup external pr tools
         uses: ./main/.github/workflows/setup-external-pr-tools
 
+      - name: Check if the user is an admin
+        id: prs_permissions
+        run: |
+          cd ops/external-prs &&
+          pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
+
       - name: Parse the comment to see if it's a deploy comment
         id: parse_comment
         run: |
           cd ./oso/ops/external-prs && pnpm tools ossd parse-comment --repo ${{ github.repository }} ${{ github.event.comment.id }} $GITHUB_OUTPUT
+        if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}
 
       - name: Login to google
         uses: "google-github-actions/auth@v2"

--- a/.github/workflows/validate-pr-owners.yml
+++ b/.github/workflows/validate-pr-owners.yml
@@ -41,12 +41,18 @@ jobs:
           cd ./oso/ops/external-prs &&
           pnpm tools initialize-check ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.user.login }} "validate"
 
+      - name: Check if the user is an admin
+        id: prs_permissions
+        run: |
+          cd ops/external-prs &&
+          pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
+
       - name: Login to google
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GOOGLE_BQ_ADMIN_CREDENTIALS_JSON }}"
           create_credentials_file: true
-        if: ${{ contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR" ]'), github.event.pull_request.author_association) }}
+        if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}
 
       - name: Run validation
         uses: ./main/.github/workflows/validate
@@ -61,4 +67,4 @@ jobs:
           arbitrum_rpc_url: ${{ secrets.PR_TOOLS_ARBITRUM_RPC_URL }}
           base_rpc_url: ${{ secrets.PR_TOOLS_BASE_RPC_URL }}
           optimism_rpc_url: ${{ secrets.PR_TOOLS_OPTIMISM_RPC_URL }}
-        if: ${{ contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR" ]'), github.event.pull_request.author_association) }}
+        if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}


### PR DESCRIPTION
This PR updates the permissions checks for workflow steps. Previously, important steps like `validate` were executed when the user had the roles `OWNER`, `MEMBER`, or `COLLABORATOR`. Now, these steps will only run if the user is an `admin` as defined by the `oso` PR tools, aligning with the permissions model in the `oso` repository. This change ensures consistency in permissions across the project.
