### PR TITLE
fix: oso workflow `tools` path

### DIFF
--- a/.github/workflows/external-prs-handle-comment.yml
+++ b/.github/workflows/external-prs-handle-comment.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check if the user is an admin
         id: prs_permissions
         run: |
-          cd ops/external-prs &&
+          cd ./oso/ops/external-prs &&
           pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
 
       - name: Parse the comment to see if it's a deploy comment

--- a/.github/workflows/validate-pr-owners.yml
+++ b/.github/workflows/validate-pr-owners.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check if the user is an admin
         id: prs_permissions
         run: |
-          cd ops/external-prs &&
+          cd ./oso/ops/external-prs &&
           pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
 
       - name: Login to google


### PR DESCRIPTION
This PR addresses an oversight where the path for the oso tools was incorrectly configured. The changes ensure that the tools are now correctly set up.