### PR TITLE
fix: revert `workflow` permissions fix

### DIFF
--- a/.github/workflows/external-prs-handle-comment.yml
+++ b/.github/workflows/external-prs-handle-comment.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check if the user is an admin
         id: prs_permissions
         run: |
-          cd ./oso/ops/external-prs &&
+          cd ops/external-prs &&
           pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
 
       - name: Parse the comment to see if it's a deploy comment

--- a/.github/workflows/external-prs-handle-comment.yml
+++ b/.github/workflows/external-prs-handle-comment.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # This job only runs for pull request comments
-    if: github.event.issue.pull_request
+    if: github.event.issue.pull_request && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,17 +29,10 @@ jobs:
       - name: Setup external pr tools
         uses: ./main/.github/workflows/setup-external-pr-tools
 
-      - name: Check if the user is an admin
-        id: prs_permissions
-        run: |
-          cd ops/external-prs &&
-          pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
-
       - name: Parse the comment to see if it's a deploy comment
         id: parse_comment
         run: |
           cd ./oso/ops/external-prs && pnpm tools ossd parse-comment --repo ${{ github.repository }} ${{ github.event.comment.id }} $GITHUB_OUTPUT
-        if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}
 
       - name: Login to google
         uses: "google-github-actions/auth@v2"

--- a/.github/workflows/validate-pr-owners.yml
+++ b/.github/workflows/validate-pr-owners.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check if the user is an admin
         id: prs_permissions
         run: |
-          cd ./oso/ops/external-prs &&
+          cd ops/external-prs &&
           pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
 
       - name: Login to google

--- a/.github/workflows/validate-pr-owners.yml
+++ b/.github/workflows/validate-pr-owners.yml
@@ -41,18 +41,12 @@ jobs:
           cd ./oso/ops/external-prs &&
           pnpm tools initialize-check ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.user.login }} "validate"
 
-      - name: Check if the user is an admin
-        id: prs_permissions
-        run: |
-          cd ops/external-prs &&
-          pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
-
       - name: Login to google
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GOOGLE_BQ_ADMIN_CREDENTIALS_JSON }}"
           create_credentials_file: true
-        if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}
+        if: ${{ contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR" ]'), github.event.pull_request.author_association) }}
 
       - name: Run validation
         uses: ./main/.github/workflows/validate
@@ -67,4 +61,4 @@ jobs:
           arbitrum_rpc_url: ${{ secrets.PR_TOOLS_ARBITRUM_RPC_URL }}
           base_rpc_url: ${{ secrets.PR_TOOLS_BASE_RPC_URL }}
           optimism_rpc_url: ${{ secrets.PR_TOOLS_OPTIMISM_RPC_URL }}
-        if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}
+        if: ${{ contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR" ]'), github.event.pull_request.author_association) }}


### PR DESCRIPTION
This reverts the last two commits to restore functionality while troubleshooting an issue with workflow execution. For details, see [this run](https://github.com/opensource-observer/oss-directory/actions/runs/11150794261/job/30992769940).
