### PR TITLE
fix: pull requests workflow permissions

### DIFF
--- a/.github/workflows/external-prs-handle-comment.yml
+++ b/.github/workflows/external-prs-handle-comment.yml
@@ -3,6 +3,7 @@ name: external-prs-handle-comment
 env:
   PR_TOOLS_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PR_TOOLS_GITHUB_APP_PRIVATE_KEY }}
   PR_TOOLS_GITHUB_APP_ID: ${{ secrets.PR_TOOLS_GITHUB_APP_ID }}
+  PR_TOOLS_ADMIN_TEAM_NAME: ${{ secrets.PR_TOOLS_ADMIN_TEAM_NAME }}
 
 on:
   issue_comment:
@@ -17,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # This job only runs for pull request comments
-    if: github.event.issue.pull_request && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
+    if: github.event.issue.pull_request
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -29,10 +30,16 @@ jobs:
       - name: Setup external pr tools
         uses: ./main/.github/workflows/setup-external-pr-tools
 
+      - name: Check if the user is an admin
+        id: prs_permissions
+        run: |
+          cd ./oso/ops/external-prs && pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
+
       - name: Parse the comment to see if it's a deploy comment
         id: parse_comment
         run: |
           cd ./oso/ops/external-prs && pnpm tools ossd parse-comment --repo ${{ github.repository }} ${{ github.event.comment.id }} $GITHUB_OUTPUT
+        if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}
 
       - name: Login to google
         uses: "google-github-actions/auth@v2"

--- a/.github/workflows/validate-pr-owners.yml
+++ b/.github/workflows/validate-pr-owners.yml
@@ -7,6 +7,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PR_TOOLS_GITHUB_APP_PRIVATE_KEY: ${{ secrets.PR_TOOLS_GITHUB_APP_PRIVATE_KEY }}
   PR_TOOLS_GITHUB_APP_ID: ${{ secrets.PR_TOOLS_GITHUB_APP_ID }}
+  PR_TOOLS_ADMIN_TEAM_NAME: ${{ secrets.PR_TOOLS_ADMIN_TEAM_NAME }}
 
   PR_TOOLS_REPO: ${{ github.repository }}
 
@@ -41,12 +42,17 @@ jobs:
           cd ./oso/ops/external-prs &&
           pnpm tools initialize-check ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.user.login }} "validate"
 
+      - name: Check if the user is an admin
+        id: prs_permissions
+        run: |
+          cd ./oso/ops/external-prs && pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
+
       - name: Login to google
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GOOGLE_BQ_ADMIN_CREDENTIALS_JSON }}"
           create_credentials_file: true
-        if: ${{ contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR" ]'), github.event.pull_request.author_association) }}
+        if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}
 
       - name: Run validation
         uses: ./main/.github/workflows/validate
@@ -61,4 +67,4 @@ jobs:
           arbitrum_rpc_url: ${{ secrets.PR_TOOLS_ARBITRUM_RPC_URL }}
           base_rpc_url: ${{ secrets.PR_TOOLS_BASE_RPC_URL }}
           optimism_rpc_url: ${{ secrets.PR_TOOLS_OPTIMISM_RPC_URL }}
-        if: ${{ contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR" ]'), github.event.pull_request.author_association) }}
+        if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}


### PR DESCRIPTION
This PR updates the workflow permissions, allowing whitelisted members to run workflows. It replaces the previous functionality, which allowed collaborators, members, and owners to run workflows but unintentionally restricted some core OSO members from deploying them as well.

**Action Required:**

- [x] Set the `PR_TOOLS_ADMIN_TEAM_NAME` secret in the repository's Secrets tab. Use the same value as set in the main `oso` repository.
