### PR TITLE
feat: add a `named` type to the JSON schema

### DIFF
--- a/src/resources/schema/named.json
+++ b/src/resources/schema/named.json
@@ -1,0 +1,12 @@
+{
+  "$id": "named.json",
+  "title": "Named Entity",
+  "type": "object",
+  "description": "A generic named object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
* Named just has a simple named object
* We can extend this later for other types
* Note that we don't actually use this anywhere yet