### PR TITLE
fix: rename cargo => crates in the schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oss-directory",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Open source software directory",
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oss-directory"
-version = "0.2.2"
+version = "0.2.3"
 description = "Open source software directory"
 authors = ["Kariba Labs"]
 license = "Apache-2.0"

--- a/src/resources/schema/project.json
+++ b/src/resources/schema/project.json
@@ -37,7 +37,7 @@
         "$ref": "url.json#"
       }
     },
-    "cargo": {
+    "crates": {
       "type": "array",
       "items": {
         "$ref": "url.json#"

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -17,7 +17,7 @@ export interface Project {
   social?: SocialProfile;
   github?: URL[];
   npm?: URL[];
-  cargo?: URL[];
+  crates?: URL[];
   pypi?: URL[];
   go?: URL[];
   open_collective?: URL[];


### PR DESCRIPTION
* Looks like we've been using crates all this time, but didn't notice that it didn't match the schema.
* Updated the schema to reflect this
* Published new versions to npm/pypi