### PR TITLE
fix: use correct `event` payload

### DIFF
--- a/.github/workflows/external-prs-handle-comment.yml
+++ b/.github/workflows/external-prs-handle-comment.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check if the user is an admin
         id: prs_permissions
         run: |
-          cd ./oso/ops/external-prs && pnpm tools common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
+          cd ./oso/ops/external-prs && pnpm tools common is-repo-admin ${{ github.event.issue.user.login }} --output-file $GITHUB_OUTPUT
 
       - name: Parse the comment to see if it's a deploy comment
         id: parse_comment


### PR DESCRIPTION
This PR uses the correct event type for the `handle-comment` CI workflow.