### PR TITLE
fix: remove `invalid` defillama slugs

### DIFF
--- a/data/projects/a/aave.yaml
+++ b/data/projects/a/aave.yaml
@@ -20,7 +20,6 @@ defillama:
   - url: https://defillama.com/protocol/aave-v1
   - url: https://defillama.com/protocol/aave-v2
   - url: https://defillama.com/protocol/aave-v3
-  - url: https://defillama.com/protocol/aave_arc
 blockchain:
   - address: "0x9a187663e454e99cafd40a2712606cc306e301b2"
     networks:

--- a/data/projects/k/kelp-dao.yaml
+++ b/data/projects/k/kelp-dao.yaml
@@ -11,9 +11,6 @@ social:
     - url: https://t.me/KelpDAOxyz
 github:
   - url: https://github.com/kelp-dao
-defillama:
-  - url: https://defillama.com/protocol/kelp-gain
-  - url: https://defillama.com/protocol/kelp-rseth
 blockchain:
   - address: "0x0c5527b3abfbd0c297104b12be6f288d335b299c"
     networks:

--- a/data/projects/p/pancakeswap.yaml
+++ b/data/projects/p/pancakeswap.yaml
@@ -14,9 +14,6 @@ defillama:
   - url: https://defillama.com/protocol/pancakeswap-amm
   - url: https://defillama.com/protocol/pancakeswap-amm-v1
   - url: https://defillama.com/protocol/pancakeswap-amm-v3
-  - url: https://defillama.com/protocol/pancakeswap-amm-stableswap
-  - url: https://defillama.com/protocol/pancakeswap-amm-perps
-  - url: https://defillama.com/protocol/pancakeswap-amm-options
 blockchain:
   - address: "0xdfa1a2df1ff153ab2afc327661e8414f2d04b3e3"
     networks:
@@ -114,7 +111,6 @@ blockchain:
       - contract
     name: NonfungiblePositionManager
 
-
   - address: "0xbC203d7f83677c7ed3F7acEc959963E7F4ECC5C2"
     networks:
       - base
@@ -163,4 +159,3 @@ blockchain:
     tags:
       - contract
     name: MasterchefV3
-


### PR DESCRIPTION
This PR fixes #690 by removing the invalid slugs and adding logic to validate Defillama protocol URLs when running `pnpm run validate`.