### PR TITLE
 fix: decouple `defillama` validation from project validation

### DIFF
--- a/src/actions/defillama.ts
+++ b/src/actions/defillama.ts
@@ -1,0 +1,59 @@
+import assert from "assert";
+import { glob } from "glob";
+import path from "path";
+import { getFileFormat, getFileExtension } from "../types/files.js";
+import { ValidateArgs } from "./validate.js";
+import { readProjectFile } from "../validator/index.js";
+
+const DEFILLAMA_API_BASE_URL = "https://api.llama.fi";
+
+/**
+ * Extracts a Defillama slug from a URL
+ * @param url
+ */
+const extractDefillamaSlug = (url: URL) => {
+  if (url.hostname !== "defillama.com") {
+    return null;
+  }
+  const match = url.pathname.match(/^\/protocol\/(.+)$/);
+
+  return match ? match[1] : null;
+};
+
+/**
+ * Validates a Defillama slug
+ * @param slug
+ */
+const validateDefillamaSlug = async (slug: string) => {
+  const request = await fetch(`${DEFILLAMA_API_BASE_URL}/protocol/${slug}`, {
+    method: "HEAD",
+    headers: {
+      "User-Agent": "OpenSource Observer/1.0",
+    },
+  });
+
+  return request.ok;
+};
+
+export async function validateDefillamaSlugs(args: ValidateArgs) {
+  const fileFormat = getFileFormat(args.format);
+  const extension = getFileExtension(fileFormat);
+  const files = await glob(path.resolve(args.dir, `**/*${extension}`));
+  for (const file of files) {
+    try {
+      const project = await readProjectFile(file, { format: fileFormat });
+      // Check that all Defillama slugs are valid
+      await project.defillama?.reduce(async (prev, { url }) => {
+        await prev;
+        const slug = extractDefillamaSlug(new URL(url));
+        assert(slug, `Could not extract Defillama slug from ${url}: ${file}`);
+        const isValid = await validateDefillamaSlug(slug);
+        assert(isValid, `Defillama slug ${slug} is invalid: ${file}`);
+      }, Promise.resolve());
+    } catch (e) {
+      console.error("Error validating ", file);
+      throw e;
+    }
+  }
+  console.log(`Success! Validated ${files.length} files`);
+}

--- a/src/actions/validate.ts
+++ b/src/actions/validate.ts
@@ -9,35 +9,9 @@ import { CommonArgs } from "../types/cli.js";
 import { getFileExtension, getFileFormat } from "../types/files.js";
 
 const IGNORE_GLOB = "**/README.md";
-const DEFILLAMA_API_BASE_URL = "https://api.llama.fi";
 
 export type ValidateArgs = CommonArgs & {
   dir: string;
-};
-
-/**
- * Extracts a Defillama slug from a URL
- * @param url
- */
-const extractDefillamaSlug = (url: URL) => {
-  const match = url.pathname.match(/^\/protocol\/(.+)$/);
-
-  return match ? match[1] : null;
-};
-
-/**
- * Validates a Defillama slug
- * @param slug
- */
-const validateDefillamaSlug = async (slug: string) => {
-  const request = await fetch(`${DEFILLAMA_API_BASE_URL}/protocol/${slug}`, {
-    method: "HEAD",
-    headers: {
-      "User-Agent": "OpenSource Observer/1.0",
-    },
-  });
-
-  return request.ok;
 };
 
 /**
@@ -154,14 +128,6 @@ export async function validateProjects(args: ValidateArgs) {
       project.blockchain?.forEach((x) =>
         x.networks.forEach((n) => addKey(`${n}:${x.address}`, file)),
       );
-      // Check that all Defillama slugs are valid
-      await project.defillama?.reduce(async (prev, { url }) => {
-        await prev;
-        const slug = extractDefillamaSlug(new URL(url));
-        assert(slug, `Could not extract Defillama slug from ${url}: ${file}`);
-        const isValid = await validateDefillamaSlug(slug);
-        assert(isValid, `Defillama slug ${slug} is invalid: ${file}`);
-      }, Promise.resolve());
     } catch (e) {
       console.error("Error validating ", file);
       throw e;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import {
 } from "./actions/validate.js";
 import { MigrationArgs, runMigrations } from "./actions/migrate.js";
 import { TransformationArgs, runTransformation } from "./actions/transform.js";
+import { validateDefillamaSlugs } from "./actions/defillama.js";
 
 yargs(hideBin(process.argv))
   .option("format", {
@@ -38,6 +39,18 @@ yargs(hideBin(process.argv))
       });
     },
     (argv) => validateProjects(argv),
+  )
+  .command<ValidateArgs>(
+    "validate-defillama-slugs",
+    "Validates Defillama slugs in a directory of projects",
+    (yags) => {
+      yags.option("dir", {
+        type: "string",
+        describe: "Directory to validate",
+        default: "./data/projects",
+      });
+    },
+    (argv) => validateDefillamaSlugs(argv),
   )
   .command<MigrationArgs>(
     "run-migrations",


### PR DESCRIPTION
This PR adds a new subcommand `validate-defillama-slugs`, which validates all Defillama slugs in oss-directory to check if they're valid.