### PR TITLE
projects: add Fluid

### DIFF
--- a/data/projects/f/fluid.yaml
+++ b/data/projects/f/fluid.yaml
@@ -1,0 +1,26 @@
+version: 7
+name: fluid
+display_name: Fluid
+description: Fluid is a suite of DeFi protocols. Fluid's innovative features, including its liquidity layer, automated limits, lending and vault protocols, robust oracle system, and DEX protocol, collectively create a revolutionary financial layer poised to redefine how DeFi users interact with the ecosystem. 
+websites:
+  - url: https://fluid.io
+social:
+  twitter:
+    - url: https://x.com/0xfluid
+github:
+  - url: https://github.com/Instadapp/fluid-contracts-public
+defillama: 
+    - url: https://defillama.com/protocol/fluid
+blockchain:
+  - address: "0x0ed35b1609ec45c7079e80d11149a52717e4859a"
+    networks:
+      - any_evm
+    tags:
+      - deployer
+      - eoa
+  - address: "0x910E413DBF3F6276Fe8213fF656726bDc142E08E"
+    networks:
+      - any_evm
+    tags:
+      - deployer
+      - eoa

--- a/data/projects/i/insta-dapp.yaml
+++ b/data/projects/i/insta-dapp.yaml
@@ -1,7 +1,7 @@
 version: 7
 name: insta-dapp
 display_name: InstaDapp
-description: InstaDapp is a DeFi protocol offering Fluid, a smart contract wallet with account abstraction, gas management, and contract execution capabilities. It provides a suite of DeFi apps and tools built on 5+ years of expertise. Developers can explore the protocol's features and read technical blogs for implementation details.
+description: InstaDapp offers Instadapp PRO for advanced DeFi strategies and Avoaco, a smart contract wallet with account abstraction, gas management, and contract execution capabilities. It also built Fluid, a separate project of DeFi apps and tools built on 5+ years of expertise. Developers can explore the protocol's features and read technical blogs for implementation details.
 websites:
   - url: https://instadapp.io
 social:


### PR DESCRIPTION
Adds Fluid

Note Fluid is created by Instadapp, a separate project already listed. Instadapp Defi protocols part has rebranded to Fluid, it would be better to keep those separated as the new suite of products are completely different from the previous ones. 

The listed deployer addresses deployed all contracts of the Fluid protocol suite: https://github.com/Instadapp/fluid-contracts-public/blob/main/deployments/deployments.md

Tracking all of those might be a bit much. Important are Liquidity layer (core contract holding funds) and the factories which deploy all the individual contracts: 
- Liquidity 0x52Aa899454998Be5b000Ad077a46Bbe360F4e497
- LendingFactory 0x54B91A0D94cb471F37f949c60F7Fa7935b551D03
- VaultFactory 0x324c5Dc1fC42c7a4D43d92df1eBA58a54d13Bf2d
- DexFactory 0x91716C4EDA1Fb55e84Bf8b4c7085f84285c19085
- SmartLendingFactory 0xe57227C7d5900165344b190fc7aa580bceb53B9B

