### PR TITLE
Update wieldlabs with ClubCoinDropFactory, FarTokenFactory

### DIFF
--- a/data/projects/w/wieldlabs.yaml
+++ b/data/projects/w/wieldlabs.yaml
@@ -27,7 +27,6 @@ blockchain:
   - address: "0x0e013e88a8b94ca85ee8e0c11b0899e4556bff1e"
     name: ClubCoinDropFactory
     tags:
-      - deployer
       - factory
       - contract
       - proxy
@@ -36,7 +35,6 @@ blockchain:
   - address: "0x5c4743942072d2d0772b9887770e0943a67af6b4"
     name: FarTokenFactory
     tags:
-      - deployer
       - factory
       - contract
       - proxy

--- a/data/projects/w/wieldlabs.yaml
+++ b/data/projects/w/wieldlabs.yaml
@@ -24,3 +24,21 @@ blockchain:
       - deployer
     networks:
       - optimism
+  - address: "0x0e013e88a8b94ca85ee8e0c11b0899e4556bff1e"
+    name: ClubCoinDropFactory
+    tags:
+      - deployer
+      - factory
+      - contract
+      - proxy
+    networks:
+      - base
+  - address: "0x5c4743942072d2d0772b9887770e0943a67af6b4"
+    name: FarTokenFactory
+    tags:
+      - deployer
+      - factory
+      - contract
+      - proxy
+    networks:
+      - base


### PR DESCRIPTION
Our ["Club Coin" x Farcaster](https://far.club) project uses a deployer for new "Club Coin" drops, so we cannot directly verify ownership in Optimism Retro Grants. I'm adding the deployer to OSS, which is located at [0x0e013e88a8b94ca85ee8e0c11b0899e4556bff1e](https://basescan.org/address/0x0e013e88a8b94ca85ee8e0c11b0899e4556bff1e) - ideally this should include the [NFT collection](https://opensea.io/collection/clubcoin) deployed at [0x2087dd5c0b093340c35357ba014a401ee9b16ab1](https://basescan.org/address/0x2087dd5c0b093340c35357ba014a401ee9b16ab1) automatically, thanks!

We also have a [FarTokenFactory](https://basescan.org/address/0x5c4743942072d2d0772b9887770e0943a67af6b4#code) for [FarTokens](https://far.quest/tokens).

You can view our attestation on Optimism to see I [deployed the Club Coin deployer](https://optimism.easscan.org/attestation/view/0x87a0a2e66df6d407c86684aed0250d09acb1c2440e42f7e63c51cef22ccd036b) at jcdenton.eth (0x997b0cced542b6d2a7e0bae5649afd9d0861cb4e), and I also funded [0xe41961727A953919B4e093BE13Ee8DD70fE80A19](https://etherscan.io/address/0xe41961727A953919B4e093BE13Ee8DD70fE80A19) as another address I control.