### PR TITLE
fix: remove Panoptic duplicate

### DIFF
--- a/data/projects/p/panoptic-labs.yaml
+++ b/data/projects/p/panoptic-labs.yaml
@@ -1,3 +1,0 @@
-version: 7
-name: panoptic-labs
-display_name: Panoptic Labs


### PR DESCRIPTION
The panoptic-labs.yaml file was added in the past. We weren't aware and made a new submission for Panoptic here: https://github.com/opensource-observer/oss-directory/pull/734

We'd like to replace the old panoptic file now, and just use the new one - current version here: https://github.com/opensource-observer/oss-directory/blob/main/data/projects/p/panoptic.yaml