### PR TITLE
Rebrand Magpie Protocol to fly trade

### DIFF
--- a/data/projects/m/magpieprotocol.yaml
+++ b/data/projects/m/magpieprotocol.yaml
@@ -1,6 +1,6 @@
 version: 7
 name: magpieprotocol
-display_name: Magpie Protocol
-description: Magpie Protocol is a swap execution engine for traders, agents and dapps. It aggregates liquidity on DEXs, DeFi protocols, and bridges across 18+ chains, optimizing transaction routes to provide better pricing on swaps with an optimal UX.
+display_name: fly trade
+description: fly trade aggregates liquidity from DEXs, DeFi protocols, and bridges to provide provably better pricing compared to leading aggregators, while delivering a seamless UX.
 websites:
-  - url: https://www.magpiefi.xyz
+  - url: https://www.fly.trade/


### PR DESCRIPTION
Kept the same file name and only changed the display name and description as suggested in the last PR which is closed: https://github.com/opensource-observer/oss-directory/pull/794