### PR TITLE
Add Base Pay Desk

### DIFF
--- a/data/projects/b/base-pay-desk-site-oskarasi.yaml
+++ b/data/projects/b/base-pay-desk-site-oskarasi.yaml
@@ -1,0 +1,18 @@
+version: 7
+name: base-pay-desk-site-oskarasi
+display_name: Base Pay Desk
+description: Independent ETH-on-Base payment-link checkout for creators, agencies, and service sellers, with transparent fee math and accountless merchant intake.
+websites:
+  - url: https://oskarasi.github.io/base-pay-desk-site/
+github:
+  - url: https://github.com/oskarasi/base-pay-desk-site
+blockchain:
+  - address: "0x28b5faaaf9d2be18c4cdb9d9dbdc2753c594572e"
+    networks:
+      - base
+    tags:
+      - eoa
+      - wallet
+comments:
+  - Public static deployment repo; private source repo is not listed.
+  - Independent merchant tool; not affiliated with Base, Coinbase, or official Base Pay.


### PR DESCRIPTION
Adds Base Pay Desk as a public project entry.

Scope:
- indexes the public static deployment repo only: https://github.com/oskarasi/base-pay-desk-site
- includes the live site: https://oskarasi.github.io/base-pay-desk-site/
- includes the Base revenue wallet as an EOA/wallet artifact
- does not list the private source repo or an undeployed router contract

Local validation:
- git diff --check passed
- pnpm run validate could not run in the shallow checkout because dependencies were not installed: ts-node was missing