### PR TITLE
Add Bilig

### DIFF
--- a/data/projects/b/bilig.yaml
+++ b/data/projects/b/bilig.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: bilig
+display_name: Bilig
+websites:
+  - url: https://proompteng.github.io/bilig/
+github:
+  - url: https://github.com/proompteng/bilig
+npm:
+  - url: https://www.npmjs.com/package/@bilig/headless


### PR DESCRIPTION
Adds Bilig to the Open Source Observer oss-directory.\n\nProject: https://github.com/proompteng/bilig\nPackage: https://www.npmjs.com/package/@bilig/headless\nWebsite: https://proompteng.github.io/bilig/\n\nBilig is a TypeScript formula WorkPaper runtime for Node.js services and agent tools.