### PR TITLE
Add Bilig project

### DIFF
--- a/data/projects/b/bilig.yaml
+++ b/data/projects/b/bilig.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: bilig
+display_name: Bilig
+websites:
+  - url: https://proompteng.github.io/bilig/
+github:
+  - url: https://github.com/proompteng/bilig
+npm:
+  - url: https://www.npmjs.com/package/@bilig/headless


### PR DESCRIPTION
Adds Bilig, an open-source formula WorkPaper runtime for Node.js services and agent tools, to the OSS Directory with GitHub, docs, and npm package artifacts.