### PR TITLE
feat: add Filecoin-funded projects and update collections

### DIFF
--- a/data/collections/filecoin-builders.yaml
+++ b/data/collections/filecoin-builders.yaml
@@ -43,6 +43,7 @@ projects:
   - ndlabs-leo
   - nftstorage
   - oku-trade
+  - outlier-ventures
   - ramo-network
   - secured-finance
   - spheronfdn
@@ -50,3 +51,4 @@ projects:
   - sushi
   - tablelandnetwork
   - textileio
+  - undone-labs

--- a/data/collections/filecoin-builders.yaml
+++ b/data/collections/filecoin-builders.yaml
@@ -5,7 +5,7 @@ projects:
   - algoveraai
   - application-research
   - peergos
-  - protofire-filecoin-wallet
+  - protofire-filecoin
   - trufflesuite
   - aurora-infra
   - banyancomputer
@@ -40,7 +40,6 @@ projects:
   - ndlabs-leo
   - nftstorage
   - oku-trade
-  - protofire-filecoin-wallet
   - ramo-network
   - secured-finance
   - spheronfdn

--- a/data/collections/filecoin-builders.yaml
+++ b/data/collections/filecoin-builders.yaml
@@ -2,7 +2,9 @@ version: 7
 name: filecoin-builders
 display_name: Building on Filecoin
 projects:
+  - ae-studio-filecoin
   - algoveraai
+  - alt-labs-filecoin
   - application-research
   - peergos
   - protofire-filecoin

--- a/data/collections/filecoin-builders.yaml
+++ b/data/collections/filecoin-builders.yaml
@@ -6,6 +6,7 @@ projects:
   - algoveraai
   - alt-labs-filecoin
   - application-research
+  - igalia
   - peergos
   - protofire-filecoin
   - trufflesuite

--- a/data/collections/filecoin-builders.yaml
+++ b/data/collections/filecoin-builders.yaml
@@ -9,16 +9,17 @@ projects:
   - igalia
   - peergos
   - protofire-filecoin
-  - trufflesuite
   - aurora-infra
   - banyancomputer
   - blockrockettech
+  - brave
   - celtd
   - cidgravity
   - crossfidao
   - curio-filecoin-project
   - curio-tools-web3tea
   - data-preservation-programs
+  - dataverse-os
   - drips-network
   - fil-builders
   - filecoin-saturn
@@ -27,6 +28,7 @@ projects:
   - filnote
   - filpunks
   - filswan
+  - fleekhq
   - fluencelabs
   - glifio
   - hedgey-finance
@@ -43,6 +45,7 @@ projects:
   - ndlabs-leo
   - nftstorage
   - oku-trade
+  - open-impact-foundation-arcological
   - outlier-ventures
   - ramo-network
   - secured-finance

--- a/data/collections/filecoin-dependencies.yaml
+++ b/data/collections/filecoin-dependencies.yaml
@@ -8,6 +8,7 @@ projects:
   - ipfs-shipyard
   - ipld
   - ipshipyard
+  - little-bear-labs
   - libp2p
   - multiformats
   - pion

--- a/data/collections/filecoin-infra-for-builders.yaml
+++ b/data/collections/filecoin-infra-for-builders.yaml
@@ -2,19 +2,25 @@ version: 7
 name: filecoin-infra-for-builders
 display_name: Infra for Filecoin Builders
 projects:
+  - blockscience
   - blockscout
   - checker-network
+  - consensys
   - digital-mob-filecoin
+  - edgevana
   - fidlabs
   - filecoin-checker-beck-8
   - filecoin-data-portal-davidgasquez
+  - fission-codes
   - ipfs-force-community-filscan
   - lynx-26dos
+  - n0-computer
   - open-telemetry
   - opensource-observer
   - piknik
   - probe-lab
   - starboard-ventures
   - supranational-filecoin
+  - trufflesuite
   - yellowstone-faithful-rpcpool
   - zondax

--- a/data/collections/filecoin-infra-for-builders.yaml
+++ b/data/collections/filecoin-infra-for-builders.yaml
@@ -15,5 +15,6 @@ projects:
   - piknik
   - probe-lab
   - starboard-ventures
+  - supranational-filecoin
   - yellowstone-faithful-rpcpool
   - zondax

--- a/data/collections/filecoin-infra-for-builders.yaml
+++ b/data/collections/filecoin-infra-for-builders.yaml
@@ -12,6 +12,7 @@ projects:
   - lynx-26dos
   - open-telemetry
   - opensource-observer
+  - piknik
   - probe-lab
   - starboard-ventures
   - yellowstone-faithful-rpcpool

--- a/data/collections/filecoin-retropgf.yaml
+++ b/data/collections/filecoin-retropgf.yaml
@@ -69,7 +69,7 @@ projects:
   - opensource-observer
   - orbitchinarpgf-irmago
   - probe-lab
-  - protofire-filecoin-wallet
+  - protofire-filecoin
   - reiers-filecoin
   - retrieval-tester-supercoolkayy
   - sealguard-fmsticks2

--- a/data/projects/a/ae-studio-filecoin.yaml
+++ b/data/projects/a/ae-studio-filecoin.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: ae-studio-filecoin
+display_name: AE Studio (Filecoin Projects)
+description: >-
+  AE Studio's Filecoin ecosystem work including a Lotus-based block explorer.
+websites:
+  - url: https://ae.studio
+github:
+  - url: https://github.com/agencyenterprise/filecoin-explorer-lotus

--- a/data/projects/a/agregore-browser-agregoreweb.yaml
+++ b/data/projects/a/agregore-browser-agregoreweb.yaml
@@ -8,4 +8,4 @@ social:
   twitter:
     - url: https://twitter.com/AgregoreBrowser
 github:
-  - url: https://github.com/agregoreweb/agregore-browser
+  - url: https://github.com/agregoreweb

--- a/data/projects/a/alt-labs-filecoin.yaml
+++ b/data/projects/a/alt-labs-filecoin.yaml
@@ -1,0 +1,7 @@
+version: 7
+name: alt-labs-filecoin
+display_name: Alt Labs (Filecoin Projects)
+description: >-
+  Alt Labs' Filecoin ecosystem work including the FilMine protocol stack.
+github:
+  - url: https://github.com/alt-labs/filmine-protocol-stack

--- a/data/projects/b/blockscience.yaml
+++ b/data/projects/b/blockscience.yaml
@@ -1,0 +1,5 @@
+version: 7
+name: blockscience
+display_name: BlockScience
+github:
+  - url: https://github.com/BlockScience

--- a/data/projects/i/igalia.yaml
+++ b/data/projects/i/igalia.yaml
@@ -1,0 +1,10 @@
+version: 7
+name: igalia
+display_name: Igalia
+description: >-
+  Open source consultancy contributing to web standards, browsers, and
+  networking stacks including libp2p.
+websites:
+  - url: https://www.igalia.com
+github:
+  - url: https://github.com/Igalia

--- a/data/projects/i/igalia.yaml
+++ b/data/projects/i/igalia.yaml
@@ -7,4 +7,4 @@ description: >-
 websites:
   - url: https://www.igalia.com
 github:
-  - url: https://github.com/Igalia
+  - url: https://github.com/igalia

--- a/data/projects/l/little-bear-labs.yaml
+++ b/data/projects/l/little-bear-labs.yaml
@@ -1,0 +1,10 @@
+version: 7
+name: little-bear-labs
+display_name: Little Bear Labs
+description: >-
+  Engineering firm contributing to libp2p and IPFS, including IPFS support in
+  Chromium and libp2p WebRTC.
+websites:
+  - url: https://littlebearlabs.io
+github:
+  - url: https://github.com/little-bear-labs

--- a/data/projects/o/open-impact-foundation-arcological.yaml
+++ b/data/projects/o/open-impact-foundation-arcological.yaml
@@ -1,5 +1,11 @@
 version: 7
 name: open-impact-foundation-arcological
 display_name: Open Impact Foundation Arcological
+description: >
+  Open Impact Foundation drives impactful transformation through strategic donating.
+  Revolutionizing the support of digital public goods
 github:
   - url: https://github.com/oif-admin
+  - url: https://github.com/OpenImpactFoundation
+websites:
+  - url: https://openimpact.foundation/

--- a/data/projects/o/outlier-ventures.yaml
+++ b/data/projects/o/outlier-ventures.yaml
@@ -1,0 +1,13 @@
+version: 7
+name: outlier-ventures
+display_name: Outlier Ventures
+description: >-
+  Web3 accelerator and venture firm investing in decentralized infrastructure
+  and open data networks.
+websites:
+  - url: https://outlierventures.io
+github:
+  - url: https://github.com/OutlierVentures
+social:
+  twitter:
+    - url: https://x.com/oviohq

--- a/data/projects/p/piknik.yaml
+++ b/data/projects/p/piknik.yaml
@@ -1,0 +1,10 @@
+version: 7
+name: piknik
+display_name: PikNik
+description: >-
+  PiKNiK is the leading provider of enterprise-grade infrastructure, optimized for the next generation of the Internet
+websites:
+  - url: https://www.piknik.com/
+social:
+  twitter:
+    - url: https://x.com/piknik_us

--- a/data/projects/p/protofire-filecoin-wallet.yaml
+++ b/data/projects/p/protofire-filecoin-wallet.yaml
@@ -1,7 +1,0 @@
-version: 7
-name: protofire-filecoin-wallet
-display_name: Protofire Filecoin Wallet
-description: >-
-  Filecoin web wallet by Protofire
-github:
-  - url: https://github.com/protofire/filecoin-wallet-web

--- a/data/projects/p/protofire-filecoin.yaml
+++ b/data/projects/p/protofire-filecoin.yaml
@@ -1,0 +1,16 @@
+version: 7
+name: protofire-filecoin
+display_name: Protofire (Filecoin Projects)
+description: >-
+  Protofire's Filecoin ecosystem work including Filecoin Wallet, FilPass, CID
+  Checker, subgraphs, and node infrastructure. Protofire is a spin-off of Altoros.
+websites:
+  - url: https://protofire.io
+github:
+  - url: https://github.com/protofire/filecoin-wallet-web
+  - url: https://github.com/protofire/FilPass
+  - url: https://github.com/protofire/filecoin-CID-checker
+  - url: https://github.com/protofire/filecoin-subgraph
+  - url: https://github.com/protofire/filecoin-statemarketdeals
+  - url: https://github.com/protofire/filexp
+  - url: https://github.com/protofire/filecoin-subway

--- a/data/projects/s/supranational-filecoin.yaml
+++ b/data/projects/s/supranational-filecoin.yaml
@@ -1,0 +1,13 @@
+version: 7
+name: supranational-filecoin
+display_name: Supranational (Filecoin Projects)
+description: >-
+  Supranational's Filecoin-specific work including hardware-accelerated sealing,
+  PreCommit operations, and SNARK proof generation.
+websites:
+  - url: https://supranational.net
+github:
+  - url: https://github.com/supranational/supra_seal
+  - url: https://github.com/supranational/filecoin_pc1
+  - url: https://github.com/supranational/filecoin_pc2
+  - url: https://github.com/supranational/pc2_cuda

--- a/data/projects/u/undone-labs.yaml
+++ b/data/projects/u/undone-labs.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: undone-labs
+display_name: Undone Labs
+description: >-
+  Venture building studio for decentralized tech and public goods. Builds web
+  tooling including IPFS routing modules for Nuxt.
+websites:
+  - url: https://undonelabs.com
+  - url: https://undoneventures.com
+github:
+  - url: https://github.com/undone-labs


### PR DESCRIPTION
## Summary
- Add 9 new projects discovered during Filecoin funding reconciliation: ae-studio-filecoin, alt-labs-filecoin, blockscience, igalia, little-bear-labs, outlier-ventures, piknik, supranational-filecoin, undone-labs
- Consolidate protofire-filecoin-wallet into protofire-filecoin
- Add brave, dataverse-os, fleekhq, open-impact-foundation-arcological to filecoin-builders
- Move blockscience, consensys, edgevana, fission-codes, n0-computer, trufflesuite to filecoin-infra-for-builders
- Enrich open-impact-foundation-arcological with description, websites, additional GitHub org
- Fix agregore-browser GitHub URL to org level and igalia URL casing

## Context
These projects were identified through a reconciliation of Filecoin funding data (IFG, OIF, PLFIF, FF sources) against oss-directory. The collection placement follows the existing split: application-layer projects in filecoin-builders, research/tooling/infra in filecoin-infra-for-builders.

## Test plan
- [ ] `pnpm run validate` passes
- [ ] `pnpm lint` passes
- [ ] No duplicate project slugs across collections (duplicates are allowed but none are intended here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)