### PR TITLE
feat: add Mneme HQ project

### DIFF
--- a/data/projects/m/mneme-theov823.yaml
+++ b/data/projects/m/mneme-theov823.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: mneme-theov823
+display_name: Mneme HQ
+description: Architectural governance layer for AI-assisted development. Enforces prior architectural decisions on every LLM call via deterministic retrieval and pre-flight enforcement.
+websites:
+- url: https://mnemehq.com/
+github:
+- url: https://github.com/TheoV823/mneme

--- a/data/projects/m/mneme-theov823.yaml
+++ b/data/projects/m/mneme-theov823.yaml
@@ -3,6 +3,6 @@ name: mneme-theov823
 display_name: Mneme HQ
 description: Architectural governance layer for AI-assisted development. Enforces prior architectural decisions on every LLM call via deterministic retrieval and pre-flight enforcement.
 websites:
-- url: https://mnemehq.com/
+  - url: https://mnemehq.com/
 github:
-- url: https://github.com/TheoV823/mneme
+  - url: https://github.com/TheoV823/mneme


### PR DESCRIPTION
Adds Mneme HQ to the OSS directory.

Mneme HQ is an architectural governance layer for AI-assisted development. It enforces prior architectural decisions on every LLM call via deterministic retrieval and pre-flight enforcement.

- GitHub: https://github.com/TheoV823/mneme
- - Site: https://mnemehq.com
- - License: MIT
- - Language: Python