### PR TITLE
Add Agent Ops Prompt Generator

### DIFF
--- a/data/projects/a/agent-ops-prompt-generator-mysubb01.yaml
+++ b/data/projects/a/agent-ops-prompt-generator-mysubb01.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: agent-ops-prompt-generator-mysubb01
+display_name: Agent Ops Prompt Generator
+description: Local-first Korean prompt generator for AI coding agent operations workflows.
+websites:
+  - url: https://mysubb01.github.io/agent-ops-prompt-generator/
+github:
+  - url: https://github.com/mysubb01/agent-ops-prompt-generator


### PR DESCRIPTION
Adds Agent Ops Prompt Generator, a free MIT-licensed local-first browser tool for generating Korean AI coding agent operations prompts.\n\nLive tool: https://mysubb01.github.io/agent-ops-prompt-generator/\nSource: https://github.com/mysubb01/agent-ops-prompt-generator