### PR TITLE
feat: add keypo-us and kencloud-tech to filecoin-retropgf

### DIFF
--- a/data/collections/filecoin-retropgf.yaml
+++ b/data/collections/filecoin-retropgf.yaml
@@ -57,6 +57,8 @@ projects:
   - ipfs-force-community-filscan
   - ipfs-force-community-venus-hub
   - ipshipyard
+  - kencloud-tech
+  - keypo-us
   - libp2p
   - lighthouse-web3
   - lily-filecoin-project


### PR DESCRIPTION
## Summary

Adds `keypo-us` and `kencloud-tech` to the `filecoin-retropgf` collection. Both projects already have YAMLs in oss-directory but weren't tagged into any Filecoin collection, so the Filecoin pipeline's `bridge_drips_to_oso` couldn't resolve their Drips RetroPGF applications (their repos showed up as orphans even though oss-directory entries existed).

## Context

Surfaced by `scripts/propose_registry_matches.py` in insights-private (OSO-2720). The bridge joins against the Filecoin-scoped staging view, which is filtered to projects appearing in at least one `filecoin-*` collection — so untagged projects get filtered out even when their oss-directory YAML is correct.

| Drips slug | Repo | Project |
|---|---|---|
| `decentralized-storage/keypo-sdk-v2` | `keypo-us/keypo-sdk-v2` | `keypo-us` |
| `kencloud-tech/kenlabs-education` | `kencloud-tech/filecoin-education` | `kencloud-tech` |

## Test plan

- [x] `pnpm validate` passes (7,065 projects, 4,108 logos)
- [x] `pnpm lint:eslint` clean
- [x] `pnpm lint:prettier` clean
- [ ] After merge: re-run `propose_registry_matches.py` in insights-private — these two should drop from the Drips orphan list once the Filecoin pipeline picks up the new collection membership

🤖 Generated with [Claude Code](https://claude.com/claude-code)