### PR TITLE
feat: consolidate strahe/curio-dashboard into curio-tools-web3tea

### DIFF
--- a/data/projects/c/curio-dashboard-strahe.yaml
+++ b/data/projects/c/curio-dashboard-strahe.yaml
@@ -1,9 +1,0 @@
-version: 7
-name: curio-dashboard-strahe
-display_name: Curio Dashboard
-description: Curio Dashboard is a web-based interface designed for monitoring
-  and analyzing the performance of your Curio cluster. It offers an intuitive
-  interface with real-time metrics and rich visualizations, helping you
-  efficiently track cluster performance and data insights.
-github:
-  - url: https://github.com/strahe/curio-dashboard

--- a/data/projects/c/curio-tools-web3tea.yaml
+++ b/data/projects/c/curio-tools-web3tea.yaml
@@ -5,6 +5,7 @@ description: Open source tooling for Filecoin storage providers running Curio
   clusters, including a web dashboard, metrics exporter, database change monitor,
   and piece storage server.
 github:
+  - url: https://github.com/strahe/curio-dashboard
   - url: https://github.com/web3tea/curio-dashboard
   - url: https://github.com/web3tea/curio-exporter
   - url: https://github.com/web3tea/curio-sentinel


### PR DESCRIPTION
## Summary

Merges the standalone `curio-dashboard-strahe` project into `curio-tools-web3tea`. The strahe repo is the original individual fork; Web3Tea maintains the active org-level version plus three other Curio tools. Treating them as one project keeps attribution clean for the upcoming Karma ProPGF match.

## Changes

- Add `https://github.com/strahe/curio-dashboard` as a GitHub URL on `curio-tools-web3tea`
- Delete the standalone `curio-dashboard-strahe.yaml`
- No collection updates needed — `curio-dashboard-strahe` wasn't referenced in any collection, and `curio-tools-web3tea` is already in `filecoin-builders` and `filecoin-retropgf`

## Test plan

- [x] `pnpm validate` passes
- [x] `grep -r curio-dashboard-strahe data/` returns nothing post-deletion
- [ ] After merge: insights-private bridge update (#TBD) repoints the Karma `curio-dashboard` slug to `curio-tools-web3tea`

🤖 Generated with [Claude Code](https://claude.com/claude-code)