### PR TITLE
Add Longevity World Cup

### DIFF
--- a/data/projects/l/longevityworldcup-nopara73.yaml
+++ b/data/projects/l/longevityworldcup-nopara73.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: longevityworldcup-nopara73
+display_name: Longevity World Cup
+description: Longevity World Cup is an open-source longevity sport platform
+  that turns healthspan measurement into a public competition with athlete
+  profiles, biological-age leaderboards, league rules, event history, and
+  blood-test-based Pheno and Bortz age flows.
+websites:
+  - url: https://www.longevityworldcup.com/
+github:
+  - url: https://github.com/nopara73/LongevityWorldCup


### PR DESCRIPTION
Adds Longevity World Cup to the OSS Directory as an MIT-licensed open-source longevity sport platform.\n\nProject details:\n- Website: https://www.longevityworldcup.com/\n- Repository: https://github.com/nopara73/LongevityWorldCup\n- Description: public competition platform for biological-age leaderboards, athlete profiles, league rules, event history, and Pheno/Bortz age flows.\n\nValidation:\n- Parsed the new YAML file locally with Python/PyYAML.\n- Full pnpm validation was not completed locally because dependency installation timed out; relying on CI for the full schema suite.