### PR TITLE
Add Orina Protocol documentation project

### DIFF
--- a/data/projects/o/orina-protocol-documentation-archiver-ka.yaml
+++ b/data/projects/o/orina-protocol-documentation-archiver-ka.yaml
@@ -1,0 +1,15 @@
+version: 7
+name: orina-protocol-documentation-archiver-ka
+display_name: Orina Protocol Documentation
+description: Public documentation and formal specification artifacts for Orina Protocol, a deterministic settlement infrastructure project for real-world asset commerce and autonomous transactions. The repository documents the Atomic Transaction Protocol, escrow-backed transaction lifecycles, settlement state transitions, security assumptions, and formal model artifacts.
+websites:
+  - url: https://www.orina.io/
+  - url: https://whitepaper.orina.io/
+  - url: https://app.orina.io/
+github:
+  - url: https://github.com/Archiver-KA/Orina-Protocol-Documentation-
+social:
+  twitter:
+    - url: https://x.com/Orina_official
+  telegram:
+    - url: https://t.me/orinaofficial


### PR DESCRIPTION
Adds Orina Protocol Documentation to OSO's project directory.

Artifacts included:
- Public documentation and formal specification repository
- Official website, whitepaper, and runtime app links
- Official X and Telegram links

Note: The ORI BNB/BSC token contract is intentionally not included as a blockchain artifact because the current OSO network schema does not list BNB/BSC as a supported network key.