### PR TITLE
Add HealthSync project

### DIFF
--- a/data/projects/h/healthykit-megabyte0x.yaml
+++ b/data/projects/h/healthykit-megabyte0x.yaml
@@ -3,6 +3,6 @@ name: healthykit-megabyte0x
 display_name: HealthSync
 description: Privacy-first iOS Apple Health app sync for private APIs and self-hosted backends.
 websites:
-  - url: https://web-megabytes-projects.vercel.app/apple-health-app-sync
+  - url: https://healthsync.megabyte.sh/apple-health-app-sync
 github:
   - url: https://github.com/megabyte0x/healthykit

--- a/data/projects/h/healthykit-megabyte0x.yaml
+++ b/data/projects/h/healthykit-megabyte0x.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: healthykit-megabyte0x
+display_name: HealthSync
+description: Privacy-first iOS Apple Health app sync for private APIs and self-hosted backends.
+websites:
+  - url: https://web-megabytes-projects.vercel.app/apple-health-app-sync
+github:
+  - url: https://github.com/megabyte0x/healthykit


### PR DESCRIPTION
Adds HealthSync as an OSS Directory project.\n\nProject artifacts:\n- Website: https://web-megabytes-projects.vercel.app/apple-health-app-sync\n- GitHub: https://github.com/megabyte0x/healthykit\n\nHealthSync is a privacy-first iOS Apple Health app sync project for private APIs and self-hosted backends.