### PR TITLE
Update Brix project: add GitHub URL

### DIFF
--- a/data/projects/b/brix.yaml
+++ b/data/projects/b/brix.yaml
@@ -9,3 +9,5 @@ social:
     - url: https://x.com/brix_money
   telegram:
     - url: https://t.me/BrixDotMoney
+github:
+  - url: https://github.com/inverternetwork


### PR DESCRIPTION
Adds a `github` URL (`https://github.com/inverternetwork`) to the **brix** project metadata (`data/projects/b/brix.yaml`).

All other fields are already in sync with upstream; this is the one new field.

Ported from growthepAI/oss-directory#79.