### PR TITLE
Add WizPay project metadata

### DIFF
--- a/data/projects/w/wizpay.yaml
+++ b/data/projects/w/wizpay.yaml
@@ -1,0 +1,13 @@
+version: 7
+name: wizpay
+display_name: WizPay
+description: WizPay is a programmable stablecoin payment and settlement layer on Arc, supporting USDC/EURC payments, swaps, bridge flows, and merchant-style payment execution.
+websites:
+  - url: https://app.wizpay.xyz
+social:
+  twitter:
+    - url: https://x.com/wizpay_arc
+github:
+  - url: https://github.com/deseti/wizpay-core
+comments: |
+  WizPay is deployed on Arc Testnet chainId 5042002. Main verified contract: 0x87ACE45582f45cC81AC1E627E875AE84cbd75946. The contract is used as a programmable payment router for USDC/EURC payments, swaps, bridge flows, and settlement on Arc.


### PR DESCRIPTION
Adds WizPay project metadata for OLI.

WizPay is a programmable stablecoin payment and settlement layer on Arc, supporting USDC/EURC payments, swaps, bridge flows, and merchant-style payment execution.

Main verified contract on Arc Testnet:
0x87ACE45582f45cC81AC1E627E875AE84cbd75946
