### PR TITLE
Add Walletbeat project

### DIFF
--- a/data/projects/w/walletbeat.yaml
+++ b/data/projects/w/walletbeat.yaml
@@ -1,0 +1,13 @@
+version: 7
+name: walletbeat
+display_name: Walletbeat
+
+websites:
+  - url: https://beta.walletbeat.eth.limo
+
+social:
+  farcaster:
+    - url: https://farcaster.xyz/~/channel/walletbeat
+
+github:
+  - url: https://github.com/walletbeat/walletbeat


### PR DESCRIPTION
Adds Walletbeat to the OSS Directory.

Walletbeat is an open repository of EVM-compatible wallets focused on transparency, privacy, and security in the Ethereum wallet ecosystem.

This PR adds the Walletbeat project entry under `data/projects/w/`.
