### PR TITLE
Add AI Language Partner project

### DIFF
--- a/data/projects/a/ai-language-partner-duct-tape2.yaml
+++ b/data/projects/a/ai-language-partner-duct-tape2.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: ai-language-partner-duct-tape2
+display_name: AI Language Partner
+description: >
+  A local-first Japanese speaking-practice app for Korean learners, combining an Expo/React Native client,
+  a FastAPI backend, curated dialogue-bank content, and optional local speech engines without requiring a
+  runtime LLM or paid model API for the core Daily Talk path.
+websites:
+  - url: https://duct-tape2.github.io/ai-language-partner/
+github:
+  - url: https://github.com/duct-tape2/ai-language-partner


### PR DESCRIPTION
## Summary

Adds AI Language Partner, an MIT-licensed local-first Japanese speaking-practice project for Korean learners.

The entry follows the documented single-repository naming convention and includes the public project site and GitHub repository.

## Validation

- Prettier check passed for the new YAML file
- Project schema validation passed for all 501 entries under data/projects/a
- Confirmed the project name, repository URL, and target filename are not already present

Full-repository validation currently encounters an unrelated pre-existing duplicate for inverternetwork in the upstream dataset; the new entry is not involved.