### PR TITLE
Add eltociear (AI-agent security & x402 tools)

### DIFF
--- a/data/projects/e/eltociear.yaml
+++ b/data/projects/e/eltociear.yaml
@@ -1,0 +1,25 @@
+version: 7
+name: eltociear
+display_name: eltociear - AI-agent security & x402 tools
+description: Open-source security scanners and pay-per-call x402 APIs for AI agents — MCP/skill/prompt malicious-pattern detection, ERC-20 token and EVM contract safety checks, and leaked-secret scanning. Settled in USDC on Base via HTTP 402.
+websites:
+  - url: https://eltociear-tokenguard.hf.space
+  - url: https://eltociear-skill-audit.hf.space
+  - url: https://eltociear-contract-guard.hf.space
+github:
+  - url: https://github.com/eltociear/skill-audit-mcp
+  - url: https://github.com/eltociear/tokenguard-mcp
+  - url: https://github.com/eltociear/contract-guard-mcp
+  - url: https://github.com/eltociear/secrets-audit-mcp
+  - url: https://github.com/eltociear/x402-approval-guard
+  - url: https://github.com/eltociear/mcp-security-audit-action
+  - url: https://github.com/eltociear/awesome-molt-ecosystem
+npm:
+  - url: https://www.npmjs.com/package/@eltociear/mcp-security-audit
+blockchain:
+  - address: "0x5bcda55247b238a573a968b234f788a2d35664dd"
+    networks:
+      - base
+    tags:
+      - eoa
+      - wallet


### PR DESCRIPTION
Adds `eltociear` — a set of open-source AI-agent security tools and pay-per-call x402 APIs.

**Artifacts included:**
- **GitHub** (7 repos): MCP security scanners — `skill-audit-mcp`, `tokenguard-mcp`, `contract-guard-mcp`, `secrets-audit-mcp`, `x402-approval-guard`, the `mcp-security-audit-action` GitHub Action, and the `awesome-molt-ecosystem` resource list.
- **npm**: `@eltociear/mcp-security-audit` (published, v1.0.0) — scans MCP servers / agent skills / prompts for malicious patterns.
- **blockchain**: Base EOA `0x5bcda…664dd` — the payTo address for the live x402 (USDC on Base) endpoints (tokenguard, skill-audit, contract-guard), all deployed and returning valid HTTP 402.

All are live, open-source, and free to use (pay-per-call micropayments, no signup). Validated against the schema (`version: 7`).
