### PR TITLE
Add Markstream

### DIFF
--- a/data/projects/m/markstream-vue-simon-he95.yaml
+++ b/data/projects/m/markstream-vue-simon-he95.yaml
@@ -1,0 +1,17 @@
+version: 7
+name: markstream-vue-simon-he95
+display_name: Markstream
+description: Multi-framework streaming Markdown renderers for AI chat and token streams, with packages for Vue, React, Svelte, Angular, and Vue 2. Handles incomplete Markdown, long responses, Mermaid, KaTeX, code highlighting, safe HTML, and SSR.
+websites:
+  - url: https://markstream.simonhe.me
+  - url: https://markstream-vue.simonhe.me
+github:
+  - url: https://github.com/Simon-He95/markstream-vue
+npm:
+  - url: https://www.npmjs.com/package/markstream-vue
+  - url: https://www.npmjs.com/package/markstream-react
+  - url: https://www.npmjs.com/package/markstream-svelte
+  - url: https://www.npmjs.com/package/markstream-angular
+  - url: https://www.npmjs.com/package/markstream-vue2
+  - url: https://www.npmjs.com/package/markstream-core
+  - url: https://www.npmjs.com/package/stream-markdown-parser


### PR DESCRIPTION
## Summary

Add Markstream, an MIT-licensed family of streaming Markdown renderers for AI/chat interfaces, together with its website, GitHub repository, and npm package artifacts.

## Validation

- `pnpm start validate-projects --dir ./data/projects/m` — passed (424 projects)
- `pnpm lint` — passed
- Full `pnpm run validate` currently stops on the pre-existing `data/projects/n/netlink.yaml` filename/name mismatch (`netlink.yaml` vs `netlinklabs`), unrelated to this change.

Thank you for maintaining the OSS Directory.