### PR TITLE
Add OpenPost project

### DIFF
--- a/data/projects/o/openpost-rodrgds.yaml
+++ b/data/projects/o/openpost-rodrgds.yaml
@@ -3,7 +3,7 @@ name: openpost-rodrgds
 display_name: OpenPost
 description: Open-source, self-hosted social media scheduler for publishing to Bluesky, Mastodon, X, LinkedIn, Threads, and more.
 websites:
-  - url: https://openpost.social
-  - url: https://docs.openpost.social
+  - url: https://openpo.st
+  - url: https://docs.openpo.st
 github:
-  - url: https://github.com/rodrgds/openpost
+  - url: https://github.com/getopenpost/openpost

--- a/data/projects/o/openpost-rodrgds.yaml
+++ b/data/projects/o/openpost-rodrgds.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: openpost-rodrgds
+display_name: OpenPost
+description: Open-source, self-hosted social media scheduler for publishing to Bluesky, Mastodon, X, LinkedIn, Threads, and more.
+websites:
+  - url: https://openpost.social
+  - url: https://docs.openpost.social
+github:
+  - url: https://github.com/rodrgds/openpost


### PR DESCRIPTION
Adds OpenPost, an open-source self-hosted social media scheduler.

Artifacts included:
- Website and documentation
- GitHub repository

The record uses the current version-7 schema and the documented `repo-owner` naming convention for a single-repository project.

Disclosure: I maintain OpenPost and am submitting my own project.
