### PR TITLE
Add AI Dictation

### DIFF
--- a/data/projects/a/aidictation-writingmate.yaml
+++ b/data/projects/a/aidictation-writingmate.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: aidictation-writingmate
+display_name: AI Dictation
+description: Open-source voice-to-text app for macOS, Windows, iPhone, iPad, and Android.
+websites:
+  - url: https://aidictation.com
+github:
+  - url: https://github.com/writingmate/aidictation


### PR DESCRIPTION
## Summary

- Add AI Dictation as a version 7 project definition.
- Include the canonical website and public GitHub repository as artifacts.
- Use the documented single-repository slug `aidictation-writingmate`.

## Project fit

AI Dictation is an active, public, MIT-licensed voice-to-text application for macOS, Windows, iPhone, iPad, and Android.

## Disclosure

I am affiliated with AI Dictation and am submitting the project transparently. OpenAI Codex assisted with the directory audit, YAML preparation, and validation; I reviewed the final submission against the current repository rules and schema.

## Validation

- The new project file passes the repository's `validate-projects` schema validator in isolation.
- Prettier reports the new file correctly formatted.
- `git diff --check` passes.
- Searched current project/collection data plus open and closed PRs and issues for `aidictation`, `AI Dictation`, `writingmate`, and `whispermate`; no duplicate was found.

The complete current `main` tree has two unrelated pre-existing local validation findings: `data/projects/n/netlink.yaml` has a filename/name mismatch, and `data/projects/z/zora.yaml` is not Prettier-clean. This PR changes neither file.
