### PR TITLE
Add elm.chat (elm-chat-shawnbure)

### DIFF
--- a/data/projects/e/elm-chat-shawnbure.yaml
+++ b/data/projects/e/elm-chat-shawnbure.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: elm-chat-shawnbure
+display_name: elm.chat
+description: elm.chat is an open-source, browser-based ephemeral messenger for conversations designed to disappear when a room ends. Its current implementation includes end-to-end encryption and self-hosting support and has not received an independent security audit.
+websites:
+  - url: https://elm.chat
+github:
+  - url: https://github.com/shawnbure/elm-chat


### PR DESCRIPTION
## Summary

Adds elm.chat, an open-source browser-based ephemeral messenger, to the OSO directory. The entry includes the project website and its single GitHub repository. The description explicitly notes that the current implementation has not received an independent security audit.

## Validation

- Project validation for data/projects/e: passed (344 projects)
- Logo validation: passed (4,131 logo files)
- Prettier check for the new YAML: passed
- git diff --check: passed
- Full project validation currently stops on the pre-existing data/projects/n/netlink.yaml filename/name mismatch on main
- Full lint currently stops on the pre-existing formatting warning in data/projects/z/zora.yaml on main