### PR TITLE
Add StonkPit project

### DIFF
--- a/data/projects/s/stonkpit.yaml
+++ b/data/projects/s/stonkpit.yaml
@@ -1,0 +1,6 @@
+version: 7
+name: stonkpit
+display_name: StonkPit
+description: StonkPit (stonkpit.xyz) is a proof-of-work mining protocol on Robinhood Chain (an Arbitrum-based L2) that produces verifiable on-chain randomness. Holders of StonkBrokers and Mineboys NFTs activate a broker, clock in to open a shift, grind sha256 proofs off-chain, and clock out to mint $DERP - "Decentralized Entropy from Recycled Proofs". Every clock-out folds into a rolling entropy beacon (The Ticker) that a Conductor contract sells to on-chain games of chance, giving the chain a randomness source it otherwise lacks. Built by Uncle Mac and launched in 2026 as the first Special Project through Clutch Markets' Stonk Launcher.
+websites:
+  - url: https://stonkpit.xyz


### PR DESCRIPTION
Adds `stonkpit` — a proof-of-work randomness protocol on Robinhood Chain (chain ID 4663, an Arbitrum-based L2).

### What it does

StonkBrokers / Mineboys NFT holders activate a broker, clock in to open a shift, grind sha256 proofs off-chain, and clock out to mint $DERP ("Decentralized Entropy from Recycled Proofs"). Each clock-out folds into a rolling entropy beacon (The Ticker) that a Conductor contract sells to on-chain games of chance — supplying verifiable randomness the chain otherwise lacks.

Built by Uncle Mac; launched in 2026 as the first Special Project through Clutch Markets' Stonk Launcher.

### Verification

Website: https://stonkpit.xyz

The site's own JS bundle carries a per-chain contract map; under key `4663`:

| Contract | Address | Verified on-chain name |
|---|---|---|
| mine | `0x2d0da469115232aD00159757f9d25f81D498206D` | `PitMine` |
| pit ($DERP) | `0x6543B7746ca744C4bb2198191E71f40FF04C41b9` | `Derp` (ERC-20, DERP) |
| conductor | `0x003e29260EF2f762e7f2d95C3d2b7A7f6234BcDE` | `MultiConductor` |
| merchant | `0x3bFfE8c3c53d1432088a771D095Db018c3006Eb9` | `PitMerchant` |
| bones | `0xa5Ea312739F0b674b196F1b8775522F328F911Df` | `PitBonesTable` |
| pitboys | `0x57069d845701B50F41327362C1C23789043F8DEc` | `PitBoys` (ERC-721, PITBOY) |
| pitboysMine | `0x6FeD5aE5d486A59081FDC040179CEBDA4be80511` | `PitBoysMine` |
| locker | `0xDeb8d589251717e367d0f3E9dDE5D4dB63968B40` | `PitLpLocker` |
| directory | `0xfd7816ee0B2Ea99d8f5849C901302a286b6578aa` | `PitDirectory` |

Corroborated on-chain rather than by the website alone: `PitMine`'s live getters return `pit()` = the DERP address and `cooler()` = the PitMerchant address above, matching the site map. Its verified source (`src/PitMine.sol`) also hardcodes `DELEGATE_RIGHTS = "stonkpit.mine"`.

No `blockchain:` section — Robinhood Chain is not in the `networks` enum in `blockchain-address.json`, and `any_evm` would wrongly assert these addresses on every EVM chain. Addresses recorded here as evidence instead.

Related PR: StonkBrokers (the partnered NFT collection these contracts gate on) is submitted separately.