### PR TITLE
Add StonkBrokers project

### DIFF
--- a/data/projects/s/stonkbrokers.yaml
+++ b/data/projects/s/stonkbrokers.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: stonkbrokers
+display_name: StonkBrokers
+description: StonkBrokers (stonkbrokers.cash) is a 4,444-piece ERC-721 PFP collection and NFT AMM on Robinhood Chain (an Arbitrum-based L2), created by Clutch Markets (Clutch Labs LLC). Each broker owns an ERC-6551 token-bound wallet that was seeded with tokenized stock at mint and can be activated to keep earning stock-token distributions. The project also runs the Anvil NFT AMM, where brokers trade against the $STONKBROKER ERC-20 collection token, and the Stonk Launcher token launchpad. It free-minted on 17 July 2026.
+websites:
+  - url: https://www.stonkbrokers.cash
+social:
+  twitter:
+    - url: https://x.com/ClutchMarkets


### PR DESCRIPTION
Adds `stonkbrokers` — a 4,444-piece ERC-721 PFP collection and NFT AMM on Robinhood Chain (chain ID 4663, an Arbitrum-based L2), created by Clutch Markets (Clutch Labs LLC).

### What it does

Each broker owns an ERC-6551 token-bound wallet that was seeded with tokenized stock at mint and can be activated to keep earning stock-token distributions. The project also runs the Anvil NFT AMM, where brokers trade against the $STONKBROKER ERC-20 collection token, and the Stonk Launcher token launchpad. It free-minted on 17 July 2026.

### Verification

Website: https://www.stonkbrokers.cash

X: https://x.com/ClutchMarkets — the only x.com link present on the project's own homepage.

| Contract | Address | Verified on-chain name |
|---|---|---|
| StonkBrokers NFT | `0x539CdD042c2f3d93EbC5BE7DfFf0c79F3B4fAbF0` | `StonkBrokers` (ERC-721, STONK) |
| $STONKBROKER | `0xe934e36A439C94017B64a3FecE66AF12099aBF50` | ERC-20, STONKBROKER |

No `blockchain:` section — Robinhood Chain is not in the `networks` enum in `blockchain-address.json`, and `any_evm` would wrongly assert these addresses on every EVM chain. Addresses recorded here as evidence instead.

Related PR: #1147 adds StonkPit, a separate protocol that builds on this collection (it gates mining on broker ownership and pays Clutch a partner fee share, but is a distinct team — built by Uncle Mac).