### PR TITLE
Add Steam Market Fee Calculator project

### DIFF
--- a/data/projects/s/steam-market-fee-calculator-hyunjun12312.yaml
+++ b/data/projects/s/steam-market-fee-calculator-hyunjun12312.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: steam-market-fee-calculator-hyunjun12312
+display_name: Steam Market Fee Calculator
+description: An MIT-licensed, browser-based Steam Community Market fee calculator that uses integer minor-unit arithmetic and deterministic reverse lookup to estimate buyer prices, seller proceeds, and fee components without requiring an account.
+websites:
+  - url: https://steamvaults.org/tools/steam-market-fee-calculator
+github:
+  - url: https://github.com/hyunjun12312/steam-market-fee-calculator


### PR DESCRIPTION
## What changed

Adds a project record for the MIT-licensed Steam Market Fee Calculator, including its public website and source repository.

## Why

This lets Open Source Observer associate the browser-based calculator with its maintained GitHub artifact. The description is limited to the calculator's implemented fee-estimation behavior and does not claim platform or marketplace integration.

## Validation

- Project YAML validated against `src/resources/schema/project.json` with URI format checks
- `prettier@3.1.1 --check` passed for the new file
- Both the website and source repository returned HTTP 200
