### PR TITLE
chore: quiet down dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,43 +1,42 @@
 version: 2
+
+# This repo is mostly curated YAML; the npm and pip dependencies exist only to
+# run the validation CLI. Routine version bumps aren't worth a PR each, so
+# they're off — but security fixes still come through, batched into one PR per
+# ecosystem rather than one per advisory.
 updates:
-  # Node dependencies (pnpm-lock.yaml)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    # 0 disables routine version updates. Security updates are exempt from this
+    # limit and are unaffected.
+    open-pull-requests-limit: 0
     groups:
-      npm-production:
-        dependency-type: "production"
-        update-types:
-          - "minor"
-          - "patch"
-      npm-development:
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
-  # Python dependencies (poetry.lock)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     groups:
-      pip-all:
+      pip-security:
+        applies-to: security-updates
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
-  # GitHub Actions used by the workflows in .github/workflows
+  # Actions are the exception: there are only a handful, and a version update is
+  # the only way they get refreshed. One grouped PR a month.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    open-pull-requests-limit: 1
     groups:
-      actions-all:
+      github-actions:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

The config I added in #1153 was tuned like an application's — weekly PRs, prod/dev split, five open at a time. This repo is mostly curated YAML, and the npm/pip dependencies exist only to run the validation CLI, so routine version bumps aren't worth a PR each.

**What changes**

- **npm and pip:** `open-pull-requests-limit: 0`. That disables routine version updates. Per GitHub's reference, security updates are explicitly exempt from this limit — "Security update pull requests are not subject to this limit and do not count toward it" — so vulnerability fixes still come through.
- **Security updates are now grouped** per ecosystem. This is the part that actually matters for noise: there is *no* cap on security PRs, so a batch of advisories would otherwise mean one PR per advisory. Grouped, it's one.
- **github-actions** keeps version updates, since a version bump is the only way actions get refreshed and there are only a handful in use. Monthly, one grouped PR, limit 1.

**Steady state:** no PRs when nothing is vulnerable, one PR when something is.

## Trade-off

Dependencies now drift until an advisory forces the issue, so the eventual security bump may be a bigger jump. That's the right call for a data repo with a small CLI, and it's what let 208 alerts pile up unnoticed before — the fix for that was turning Dependabot on at all, not bumping versions weekly.

If you'd rather keep some routine drift control, the middle option is `interval: monthly` with a single `patterns: ["*"]` group instead of limit 0 — one PR a month covering everything.

## Test plan

Config-only; nothing executable changes.

- Parsed with the `yaml` library: `version: 2`, three ecosystems, limits and groups as intended
- `prettier --check` passes
- GitHub validates `dependabot.yml` on push and flags errors in the repo's Dependabot settings — worth a glance there after merge to confirm it took

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SCZyNzdYFs5CSRx1LtFQ9