### PR TITLE
chore: bump github actions across workflows and composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,8 +31,16 @@ updates:
 
   # Actions are the exception: there are only a handful, and a version update is
   # the only way they get refreshed. One grouped PR a month.
+  #
+  # "/" covers .github/workflows/*.yml and a root action.yml, but NOT composite
+  # actions nested in subdirectories — those have to be listed explicitly, or
+  # they silently never get updated (which is how they drifted to v4 while the
+  # workflows moved on).
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/workflows/setup-external-pr-tools"
+      - "/.github/workflows/validate"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 1

--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -35,7 +35,7 @@ jobs:
         component: ["node", "python"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Check out pull request's HEAD commit instead of the merge commit to
           # prevent gitlint from failing due to too long commit message titles,
@@ -45,7 +45,7 @@ jobs:
           fetch-depth: "0"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
           run_install: |
@@ -59,7 +59,7 @@ jobs:
           poetry-version: 1.8.2
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/external-prs-handle-comment.yml
+++ b/.github/workflows/external-prs-handle-comment.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.event.issue.pull_request
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: main
           ref: main
@@ -43,7 +43,7 @@ jobs:
         if: ${{ steps.prs_permissions.outputs.is_admin == '1' }}
 
       - name: Login to google
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           credentials_json: "${{ secrets.GOOGLE_BQ_ADMIN_CREDENTIALS_JSON }}"
           create_credentials_file: true

--- a/.github/workflows/setup-external-pr-tools/action.yml
+++ b/.github/workflows/setup-external-pr-tools/action.yml
@@ -6,12 +6,12 @@ runs:
   using: "composite"
   steps:
     - name: Set up Node.js 20
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: "20.x"
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 9
 

--- a/.github/workflows/validate-pr-owners.yml
+++ b/.github/workflows/validate-pr-owners.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: main
           fetch-depth: 1
@@ -47,7 +47,7 @@ jobs:
           pnpm exec external-prs common is-repo-admin ${{ github.event.pull_request.user.login }} --output-file $GITHUB_OUTPUT
 
       - name: Login to google
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           credentials_json: "${{ secrets.GOOGLE_BQ_ADMIN_CREDENTIALS_JSON }}"
           create_credentials_file: true

--- a/.github/workflows/validate/action.yml
+++ b/.github/workflows/validate/action.yml
@@ -52,7 +52,7 @@ runs:
         echo "PR_TOOLS_SHA=${{ inputs.sha }}" >> "$GITHUB_ENV"
 
     - name: checkout the PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ inputs.sha }}
         fetch-depth: 1


### PR DESCRIPTION
## Summary

Supersedes #1163. Same intent, but complete — and it runs the job that #1163 couldn't.

| Action | From | To | Refs |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | v7 | 4 |
| `actions/setup-node` | v4 | v7 | 2 |
| `pnpm/action-setup` | v4 | v6 | 2 |
| `google-github-actions/auth` | v2 | v3 | 2 |

## Why not just merge #1163

**It was a partial update.** Dependabot bumped the three top-level workflow files but missed three refs in the composite actions:

- `.github/workflows/setup-external-pr-tools/action.yml` — `setup-node@v4`, `action-setup@v4`
- `.github/workflows/validate/action.yml` — `checkout@v4`

That's not a Dependabot bug. With `directory: "/"` it scans `.github/workflows` and a *root* `action.yml`; composite actions nested in subdirectories are outside that scope. Left alone they'd have sat on v4 indefinitely while everything around them moved — which is exactly how they got here. `dependabot.yml` now names those two directories explicitly.

**`google-github-actions/auth@v3` was never exercised.** It only runs inside the `validate` composite, which on #1163 sat at `action_required` — "Approval required for validate" — because Dependabot is an outside actor. All the green checks there came from `test (node)`/`test (python)`, which never touch it. As a collaborator PR this one skips that gate, so `auth@v3` actually executes here. That's the main reason to take this over #1163.

## Verification

- All six changed YAML files parse
- `prettier --check` passes on `dependabot.yml`
- `pnpm/action-setup@v6` still honors `version: 9`, confirmed from #1163's run log: `Switching pnpm from v11.19.0 to v9.15.9` → `Done in 5.5s using pnpm v9.15.9`, with `--frozen-lockfile --strict-peer-dependencies`. This matters beyond the version bump: the `pnpm.overrides` added in #1161 are only read by pnpm 9, so a silent jump to pnpm 11 would have quietly dropped them.
- The real test is CI on this PR. `checkout@v7` / `setup-node@v7` / `action-setup@v6` are covered by `test (node)` and `test (python)`; `auth@v3` and the composite actions are covered by `Validate PR` and `validate`.

## Also worth knowing

`packetcoders/action-setup-cache-python-poetry@main` is pinned to a moving branch, not a tag or SHA. Dependabot can't update it and it's not something this PR changes, but a third-party action tracking `main` means arbitrary upstream code lands in CI without review. Worth pinning to a SHA separately.

Closes #1163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SCZyNzdYFs5CSRx1LtFQ9