### PR TITLE
chore(security): override old babel in jest tree, drop unused dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
   "keywords": [],
   "pnpm": {
     "overrides": {
+      "@babel/core@7": "^7.29.7",
+      "@babel/traverse@7": "^7.29.8",
       "brace-expansion@1": "^1.1.18",
       "braces@3": "^3.0.3",
       "js-yaml@3": "^3.15.1",
@@ -78,7 +80,6 @@
     "chalk": "^5.6.2",
     "csv": "^6.6.3",
     "dayjs": "^1.11.21",
-    "dotenv": "^16.6.1",
     "glob": "^10.5.0",
     "lodash": "^4.18.1",
     "mkdirp": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  "@babel/core@7": ^7.29.7
+  "@babel/traverse@7": ^7.29.8
   brace-expansion@1: ^1.1.18
   braces@3: ^3.0.3
   js-yaml@3: ^3.15.1
@@ -30,9 +32,6 @@ importers:
       dayjs:
         specifier: ^1.11.21
         version: 1.11.21
-      dotenv:
-        specifier: ^16.6.1
-        version: 16.6.1
       glob:
         specifier: ^10.5.0
         version: 10.5.0
@@ -114,31 +113,10 @@ importers:
         version: 5.9.3
 
 packages:
-  "@ampproject/remapping@2.2.1":
-    resolution:
-      {
-        integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==,
-      }
-    engines: { node: ">=6.0.0" }
-
-  "@babel/code-frame@7.22.10":
-    resolution:
-      {
-        integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/code-frame@7.29.7":
     resolution:
       {
         integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/compat-data@7.22.9":
-    resolution:
-      {
-        integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -149,24 +127,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/core@7.22.10":
-    resolution:
-      {
-        integrity: sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/core@7.29.7":
     resolution:
       {
         integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/generator@7.22.10":
-    resolution:
-      {
-        integrity: sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -177,31 +141,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-compilation-targets@7.22.10":
-    resolution:
-      {
-        integrity: sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/helper-compilation-targets@7.29.7":
     resolution:
       {
         integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-environment-visitor@7.22.5":
-    resolution:
-      {
-        integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-function-name@7.22.5":
-    resolution:
-      {
-        integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -212,35 +155,12 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-hoist-variables@7.22.5":
-    resolution:
-      {
-        integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-module-imports@7.22.5":
-    resolution:
-      {
-        integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/helper-module-imports@7.29.7":
     resolution:
       {
         integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
       }
     engines: { node: ">=6.9.0" }
-
-  "@babel/helper-module-transforms@7.22.9":
-    resolution:
-      {
-        integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==,
-      }
-    engines: { node: ">=6.9.0" }
-    peerDependencies:
-      "@babel/core": ^7.0.0
 
   "@babel/helper-module-transforms@7.29.7":
     resolution:
@@ -249,7 +169,7 @@ packages:
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
-      "@babel/core": ^7.0.0
+      "@babel/core": ^7.29.7
 
   "@babel/helper-plugin-utils@7.22.5":
     resolution:
@@ -265,38 +185,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-simple-access@7.22.5":
-    resolution:
-      {
-        integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-split-export-declaration@7.22.6":
-    resolution:
-      {
-        integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-string-parser@7.22.5":
-    resolution:
-      {
-        integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/helper-string-parser@7.29.7":
     resolution:
       {
         integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helper-validator-identifier@7.22.5":
-    resolution:
-      {
-        integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -307,24 +199,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-validator-option@7.22.5":
-    resolution:
-      {
-        integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/helper-validator-option@7.29.7":
     resolution:
       {
         integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/helpers@7.22.10":
-    resolution:
-      {
-        integrity: sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -334,21 +212,6 @@ packages:
         integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==,
       }
     engines: { node: ">=6.9.0" }
-
-  "@babel/highlight@7.22.10":
-    resolution:
-      {
-        integrity: sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/parser@7.22.10":
-    resolution:
-      {
-        integrity: sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==,
-      }
-    engines: { node: ">=6.0.0" }
-    hasBin: true
 
   "@babel/parser@7.29.8":
     resolution:
@@ -364,7 +227,7 @@ packages:
         integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-bigint@7.8.3":
     resolution:
@@ -372,7 +235,7 @@ packages:
         integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-class-properties@7.12.13":
     resolution:
@@ -380,7 +243,7 @@ packages:
         integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-class-static-block@7.14.5":
     resolution:
@@ -389,7 +252,7 @@ packages:
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-import-attributes@7.29.7":
     resolution:
@@ -398,7 +261,7 @@ packages:
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-import-meta@7.10.4":
     resolution:
@@ -406,7 +269,7 @@ packages:
         integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-json-strings@7.8.3":
     resolution:
@@ -414,7 +277,7 @@ packages:
         integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-jsx@7.29.7":
     resolution:
@@ -423,7 +286,7 @@ packages:
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-logical-assignment-operators@7.10.4":
     resolution:
@@ -431,7 +294,7 @@ packages:
         integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3":
     resolution:
@@ -439,7 +302,7 @@ packages:
         integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-numeric-separator@7.10.4":
     resolution:
@@ -447,7 +310,7 @@ packages:
         integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-object-rest-spread@7.8.3":
     resolution:
@@ -455,7 +318,7 @@ packages:
         integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-optional-catch-binding@7.8.3":
     resolution:
@@ -463,7 +326,7 @@ packages:
         integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-optional-chaining@7.8.3":
     resolution:
@@ -471,7 +334,7 @@ packages:
         integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-private-property-in-object@7.14.5":
     resolution:
@@ -480,7 +343,7 @@ packages:
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-top-level-await@7.14.5":
     resolution:
@@ -489,7 +352,7 @@ packages:
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      "@babel/core": ^7.29.7
 
   "@babel/plugin-syntax-typescript@7.29.7":
     resolution:
@@ -498,14 +361,7 @@ packages:
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
-      "@babel/core": ^7.0.0-0
-
-  "@babel/template@7.22.5":
-    resolution:
-      {
-        integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==,
-      }
-    engines: { node: ">=6.9.0" }
+      "@babel/core": ^7.29.7
 
   "@babel/template@7.29.7":
     resolution:
@@ -514,24 +370,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/traverse@7.22.10":
-    resolution:
-      {
-        integrity: sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==,
-      }
-    engines: { node: ">=6.9.0" }
-
   "@babel/traverse@7.29.8":
     resolution:
       {
         integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==,
-      }
-    engines: { node: ">=6.9.0" }
-
-  "@babel/types@7.22.10":
-    resolution:
-      {
-        integrity: sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -769,13 +611,6 @@ packages:
         integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
       }
 
-  "@jridgewell/gen-mapping@0.3.3":
-    resolution:
-      {
-        integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==,
-      }
-    engines: { node: ">=6.0.0" }
-
   "@jridgewell/remapping@2.3.5":
     resolution:
       {
@@ -793,13 +628,6 @@ packages:
     resolution:
       {
         integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-      }
-    engines: { node: ">=6.0.0" }
-
-  "@jridgewell/set-array@1.1.2":
-    resolution:
-      {
-        integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==,
       }
     engines: { node: ">=6.0.0" }
 
@@ -1240,13 +1068,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  ansi-styles@3.2.1:
-    resolution:
-      {
-        integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==,
-      }
-    engines: { node: ">=4" }
-
   ansi-styles@4.3.0:
     resolution:
       {
@@ -1319,7 +1140,7 @@ packages:
       }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     peerDependencies:
-      "@babel/core": ^7.8.0
+      "@babel/core": ^7.29.7
 
   babel-plugin-istanbul@6.1.1:
     resolution:
@@ -1341,7 +1162,7 @@ packages:
         integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0
+      "@babel/core": ^7.29.7
 
   babel-preset-current-node-syntax@1.2.0:
     resolution:
@@ -1349,7 +1170,7 @@ packages:
         integrity: sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==,
       }
     peerDependencies:
-      "@babel/core": ^7.0.0 || ^8.0.0-0
+      "@babel/core": ^7.29.7
 
   babel-preset-jest@29.6.3:
     resolution:
@@ -1358,7 +1179,7 @@ packages:
       }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     peerDependencies:
-      "@babel/core": ^7.0.0
+      "@babel/core": ^7.29.7
 
   balanced-match@1.0.2:
     resolution:
@@ -1392,14 +1213,6 @@ packages:
         integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
       }
     engines: { node: ">=8" }
-
-  browserslist@4.21.10:
-    resolution:
-      {
-        integrity: sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==,
-      }
-    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
-    hasBin: true
 
   browserslist@4.28.7:
     resolution:
@@ -1455,24 +1268,11 @@ packages:
       }
     engines: { node: ">=10" }
 
-  caniuse-lite@1.0.30001519:
-    resolution:
-      {
-        integrity: sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==,
-      }
-
   caniuse-lite@1.0.30001807:
     resolution:
       {
         integrity: sha512-daRXJ9EB/rdRgu7kV+TTl1YUKtlsMWblPl2sLnpg9DZae16QCegol6A1SmCE31Lm9mXC1sRWGt/krouH+/dl7Q==,
       }
-
-  chalk@2.4.2:
-    resolution:
-      {
-        integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==,
-      }
-    engines: { node: ">=4" }
 
   chalk@4.1.2:
     resolution:
@@ -1556,12 +1356,6 @@ packages:
         integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==,
       }
 
-  color-convert@1.9.3:
-    resolution:
-      {
-        integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==,
-      }
-
   color-convert@2.0.1:
     resolution:
       {
@@ -1575,12 +1369,6 @@ packages:
         integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==,
       }
     engines: { node: ">=14.6" }
-
-  color-name@1.1.3:
-    resolution:
-      {
-        integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==,
-      }
 
   color-name@1.1.4:
     resolution:
@@ -1626,12 +1414,6 @@ packages:
     resolution:
       {
         integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
-      }
-
-  convert-source-map@1.9.0:
-    resolution:
-      {
-        integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==,
       }
 
   convert-source-map@2.0.0:
@@ -1698,18 +1480,6 @@ packages:
       {
         integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==,
       }
-
-  debug@4.3.4:
-    resolution:
-      {
-        integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==,
-      }
-    engines: { node: ">=6.0" }
-    peerDependencies:
-      supports-color: "*"
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
 
   debug@4.4.3:
     resolution:
@@ -1782,13 +1552,6 @@ packages:
       }
     engines: { node: ">=6.0.0" }
 
-  dotenv@16.6.1:
-    resolution:
-      {
-        integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==,
-      }
-    engines: { node: ">=12" }
-
   duplexer@0.1.2:
     resolution:
       {
@@ -1799,12 +1562,6 @@ packages:
     resolution:
       {
         integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
-      }
-
-  electron-to-chromium@1.4.487:
-    resolution:
-      {
-        integrity: sha512-XbCRs/34l31np/p33m+5tdBrdXu9jJkZxSbNxj5I0H1KtV2ZMSB+i/HYqDiRzHaFx2T5EdytjoBRe8QRJE2vQg==,
       }
 
   electron-to-chromium@1.5.402:
@@ -1890,26 +1647,12 @@ packages:
         integrity: sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==,
       }
 
-  escalade@3.1.1:
-    resolution:
-      {
-        integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==,
-      }
-    engines: { node: ">=6" }
-
   escalade@3.2.0:
     resolution:
       {
         integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
       }
     engines: { node: ">=6" }
-
-  escape-string-regexp@1.0.5:
-    resolution:
-      {
-        integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==,
-      }
-    engines: { node: ">=0.8.0" }
 
   escape-string-regexp@2.0.0:
     resolution:
@@ -2266,13 +2009,6 @@ packages:
       }
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  globals@11.12.0:
-    resolution:
-      {
-        integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==,
-      }
-    engines: { node: ">=4" }
-
   globals@13.24.0:
     resolution:
       {
@@ -2306,13 +2042,6 @@ packages:
       }
     engines: { node: ">=0.4.7" }
     hasBin: true
-
-  has-flag@3.0.0:
-    resolution:
-      {
-        integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==,
-      }
-    engines: { node: ">=4" }
 
   has-flag@4.0.0:
     resolution:
@@ -2775,14 +2504,6 @@ packages:
       }
     hasBin: true
 
-  jsesc@2.5.2:
-    resolution:
-      {
-        integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==,
-      }
-    engines: { node: ">=4" }
-    hasBin: true
-
   jsesc@3.1.0:
     resolution:
       {
@@ -3084,12 +2805,6 @@ packages:
     engines: { node: ">=10" }
     hasBin: true
 
-  ms@2.1.2:
-    resolution:
-      {
-        integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==,
-      }
-
   ms@2.1.3:
     resolution:
       {
@@ -3130,12 +2845,6 @@ packages:
     resolution:
       {
         integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==,
-      }
-
-  node-releases@2.0.13:
-    resolution:
-      {
-        integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==,
       }
 
   node-releases@2.0.53:
@@ -3320,12 +3029,6 @@ packages:
     resolution:
       {
         integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==,
-      }
-
-  picocolors@1.0.0:
-    resolution:
-      {
-        integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==,
       }
 
   picocolors@1.1.1:
@@ -3753,13 +3456,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  supports-color@5.5.0:
-    resolution:
-      {
-        integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==,
-      }
-    engines: { node: ">=4" }
-
   supports-color@7.2.0:
     resolution:
       {
@@ -3845,13 +3541,6 @@ packages:
         integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==,
       }
 
-  to-fast-properties@2.0.0:
-    resolution:
-      {
-        integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==,
-      }
-    engines: { node: ">=4" }
-
   to-regex-range@5.0.1:
     resolution:
       {
@@ -3895,7 +3584,7 @@ packages:
     engines: { node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0 }
     hasBin: true
     peerDependencies:
-      "@babel/core": ">=7.0.0-beta.0 <8"
+      "@babel/core": ^7.29.7
       "@jest/transform": ^29.0.0 || ^30.0.0
       "@jest/types": ^29.0.0 || ^30.0.0
       babel-jest: ^29.0.0 || ^30.0.0
@@ -4012,15 +3701,6 @@ packages:
       {
         integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
       }
-
-  update-browserslist-db@1.0.11:
-    resolution:
-      {
-        integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==,
-      }
-    hasBin: true
-    peerDependencies:
-      browserslist: ">= 4.21.0"
 
   update-browserslist-db@1.3.0:
     resolution:
@@ -4181,45 +3861,13 @@ packages:
     engines: { node: ">=10" }
 
 snapshots:
-  "@ampproject/remapping@2.2.1":
-    dependencies:
-      "@jridgewell/gen-mapping": 0.3.3
-      "@jridgewell/trace-mapping": 0.3.19
-
-  "@babel/code-frame@7.22.10":
-    dependencies:
-      "@babel/highlight": 7.22.10
-      chalk: 2.4.2
-
   "@babel/code-frame@7.29.7":
     dependencies:
       "@babel/helper-validator-identifier": 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  "@babel/compat-data@7.22.9": {}
-
   "@babel/compat-data@7.29.7": {}
-
-  "@babel/core@7.22.10":
-    dependencies:
-      "@ampproject/remapping": 2.2.1
-      "@babel/code-frame": 7.22.10
-      "@babel/generator": 7.22.10
-      "@babel/helper-compilation-targets": 7.22.10
-      "@babel/helper-module-transforms": 7.22.9(@babel/core@7.22.10)
-      "@babel/helpers": 7.22.10
-      "@babel/parser": 7.22.10
-      "@babel/template": 7.22.5
-      "@babel/traverse": 7.22.10
-      "@babel/types": 7.22.10
-      convert-source-map: 1.9.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   "@babel/core@7.29.7":
     dependencies:
@@ -4234,19 +3882,12 @@ snapshots:
       "@babel/types": 7.29.8
       "@jridgewell/remapping": 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-
-  "@babel/generator@7.22.10":
-    dependencies:
-      "@babel/types": 7.22.10
-      "@jridgewell/gen-mapping": 0.3.3
-      "@jridgewell/trace-mapping": 0.3.19
-      jsesc: 2.5.2
 
   "@babel/generator@7.29.8":
     dependencies:
@@ -4256,14 +3897,6 @@ snapshots:
       "@jridgewell/trace-mapping": 0.3.31
       jsesc: 3.1.0
 
-  "@babel/helper-compilation-targets@7.22.10":
-    dependencies:
-      "@babel/compat-data": 7.22.9
-      "@babel/helper-validator-option": 7.22.5
-      browserslist: 4.21.10
-      lru-cache: 5.1.1
-      semver: 6.3.1
-
   "@babel/helper-compilation-targets@7.29.7":
     dependencies:
       "@babel/compat-data": 7.29.7
@@ -4272,22 +3905,7 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  "@babel/helper-environment-visitor@7.22.5": {}
-
-  "@babel/helper-function-name@7.22.5":
-    dependencies:
-      "@babel/template": 7.22.5
-      "@babel/types": 7.22.10
-
   "@babel/helper-globals@7.29.7": {}
-
-  "@babel/helper-hoist-variables@7.22.5":
-    dependencies:
-      "@babel/types": 7.22.10
-
-  "@babel/helper-module-imports@7.22.5":
-    dependencies:
-      "@babel/types": 7.22.10
 
   "@babel/helper-module-imports@7.29.7":
     dependencies:
@@ -4295,15 +3913,6 @@ snapshots:
       "@babel/types": 7.29.8
     transitivePeerDependencies:
       - supports-color
-
-  "@babel/helper-module-transforms@7.22.9(@babel/core@7.22.10)":
-    dependencies:
-      "@babel/core": 7.22.10
-      "@babel/helper-environment-visitor": 7.22.5
-      "@babel/helper-module-imports": 7.22.5
-      "@babel/helper-simple-access": 7.22.5
-      "@babel/helper-split-export-declaration": 7.22.6
-      "@babel/helper-validator-identifier": 7.22.5
 
   "@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)":
     dependencies:
@@ -4318,48 +3927,16 @@ snapshots:
 
   "@babel/helper-plugin-utils@7.29.7": {}
 
-  "@babel/helper-simple-access@7.22.5":
-    dependencies:
-      "@babel/types": 7.22.10
-
-  "@babel/helper-split-export-declaration@7.22.6":
-    dependencies:
-      "@babel/types": 7.22.10
-
-  "@babel/helper-string-parser@7.22.5": {}
-
   "@babel/helper-string-parser@7.29.7": {}
-
-  "@babel/helper-validator-identifier@7.22.5": {}
 
   "@babel/helper-validator-identifier@7.29.7": {}
 
-  "@babel/helper-validator-option@7.22.5": {}
-
   "@babel/helper-validator-option@7.29.7": {}
-
-  "@babel/helpers@7.22.10":
-    dependencies:
-      "@babel/template": 7.22.5
-      "@babel/traverse": 7.22.10
-      "@babel/types": 7.22.10
-    transitivePeerDependencies:
-      - supports-color
 
   "@babel/helpers@7.29.7":
     dependencies:
       "@babel/template": 7.29.7
       "@babel/types": 7.29.8
-
-  "@babel/highlight@7.22.10":
-    dependencies:
-      "@babel/helper-validator-identifier": 7.22.5
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-
-  "@babel/parser@7.22.10":
-    dependencies:
-      "@babel/types": 7.22.10
 
   "@babel/parser@7.29.8":
     dependencies:
@@ -4450,32 +4027,11 @@ snapshots:
       "@babel/core": 7.29.7
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/template@7.22.5":
-    dependencies:
-      "@babel/code-frame": 7.22.10
-      "@babel/parser": 7.22.10
-      "@babel/types": 7.22.10
-
   "@babel/template@7.29.7":
     dependencies:
       "@babel/code-frame": 7.29.7
       "@babel/parser": 7.29.8
       "@babel/types": 7.29.8
-
-  "@babel/traverse@7.22.10":
-    dependencies:
-      "@babel/code-frame": 7.22.10
-      "@babel/generator": 7.22.10
-      "@babel/helper-environment-visitor": 7.22.5
-      "@babel/helper-function-name": 7.22.5
-      "@babel/helper-hoist-variables": 7.22.5
-      "@babel/helper-split-export-declaration": 7.22.6
-      "@babel/parser": 7.22.10
-      "@babel/types": 7.22.10
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   "@babel/traverse@7.29.8":
     dependencies:
@@ -4485,15 +4041,9 @@ snapshots:
       "@babel/parser": 7.29.8
       "@babel/template": 7.29.7
       "@babel/types": 7.29.8
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  "@babel/types@7.22.10":
-    dependencies:
-      "@babel/helper-string-parser": 7.22.5
-      "@babel/helper-validator-identifier": 7.22.5
-      to-fast-properties: 2.0.0
 
   "@babel/types@7.29.8":
     dependencies:
@@ -4712,7 +4262,7 @@ snapshots:
 
   "@jest/transform@29.7.0":
     dependencies:
-      "@babel/core": 7.22.10
+      "@babel/core": 7.29.7
       "@jest/types": 29.6.3
       "@jridgewell/trace-mapping": 0.3.19
       babel-plugin-istanbul: 6.1.1
@@ -4744,12 +4294,6 @@ snapshots:
       "@jridgewell/sourcemap-codec": 1.5.5
       "@jridgewell/trace-mapping": 0.3.31
 
-  "@jridgewell/gen-mapping@0.3.3":
-    dependencies:
-      "@jridgewell/set-array": 1.1.2
-      "@jridgewell/sourcemap-codec": 1.4.15
-      "@jridgewell/trace-mapping": 0.3.19
-
   "@jridgewell/remapping@2.3.5":
     dependencies:
       "@jridgewell/gen-mapping": 0.3.13
@@ -4758,8 +4302,6 @@ snapshots:
   "@jridgewell/resolve-uri@3.1.1": {}
 
   "@jridgewell/resolve-uri@3.1.2": {}
-
-  "@jridgewell/set-array@1.1.2": {}
 
   "@jridgewell/sourcemap-codec@1.4.15": {}
 
@@ -4836,24 +4378,24 @@ snapshots:
 
   "@types/babel__core@7.20.1":
     dependencies:
-      "@babel/parser": 7.22.10
-      "@babel/types": 7.22.10
+      "@babel/parser": 7.29.8
+      "@babel/types": 7.29.8
       "@types/babel__generator": 7.6.4
       "@types/babel__template": 7.4.1
       "@types/babel__traverse": 7.20.1
 
   "@types/babel__generator@7.6.4":
     dependencies:
-      "@babel/types": 7.22.10
+      "@babel/types": 7.29.8
 
   "@types/babel__template@7.4.1":
     dependencies:
-      "@babel/parser": 7.22.10
-      "@babel/types": 7.22.10
+      "@babel/parser": 7.29.8
+      "@babel/types": 7.29.8
 
   "@types/babel__traverse@7.20.1":
     dependencies:
-      "@babel/types": 7.22.10
+      "@babel/types": 7.29.8
 
   "@types/glob@7.2.0":
     dependencies:
@@ -5040,10 +4582,6 @@ snapshots:
 
   ansi-regex@6.2.2: {}
 
-  ansi-styles@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
-
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -5096,8 +4634,8 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      "@babel/template": 7.22.5
-      "@babel/types": 7.22.10
+      "@babel/template": 7.29.7
+      "@babel/types": 7.29.8
       "@types/babel__core": 7.20.1
       "@types/babel__traverse": 7.20.1
 
@@ -5159,13 +4697,6 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.21.10:
-    dependencies:
-      caniuse-lite: 1.0.30001519
-      electron-to-chromium: 1.4.487
-      node-releases: 2.0.13
-      update-browserslist-db: 1.0.11(browserslist@4.21.10)
-
   browserslist@4.28.7:
     dependencies:
       baseline-browser-mapping: 2.11.12
@@ -5192,15 +4723,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001519: {}
-
   caniuse-lite@1.0.30001807: {}
-
-  chalk@2.4.2:
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
 
   chalk@4.1.2:
     dependencies:
@@ -5244,10 +4767,6 @@ snapshots:
 
   collect-v8-coverage@1.0.3: {}
 
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5255,8 +4774,6 @@ snapshots:
   color-convert@3.1.3:
     dependencies:
       color-name: 2.1.1
-
-  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -5276,8 +4793,6 @@ snapshots:
   commander@13.1.0: {}
 
   concat-map@0.0.1: {}
-
-  convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
@@ -5324,10 +4839,6 @@ snapshots:
 
   dayjs@1.11.21: {}
 
-  debug@4.3.4:
-    dependencies:
-      ms: 2.1.2
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -5352,13 +4863,9 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  dotenv@16.6.1: {}
-
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
-
-  electron-to-chromium@1.4.487: {}
 
   electron-to-chromium@1.5.402: {}
 
@@ -5405,11 +4912,7 @@ snapshots:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.4
 
-  escalade@3.1.1: {}
-
   escalade@3.2.0: {}
-
-  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -5660,8 +5163,6 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  globals@11.12.0: {}
-
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
@@ -5687,8 +5188,6 @@ snapshots:
       wordwrap: 1.0.0
     optionalDependencies:
       uglify-js: 3.19.3
-
-  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
@@ -5765,8 +5264,8 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      "@babel/core": 7.22.10
-      "@babel/parser": 7.22.10
+      "@babel/core": 7.29.7
+      "@babel/parser": 7.29.8
       "@istanbuljs/schema": 0.1.3
       istanbul-lib-coverage: 3.2.0
       semver: 6.3.1
@@ -6128,8 +5627,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsesc@2.5.2: {}
-
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
@@ -6304,8 +5801,6 @@ snapshots:
 
   mkdirp@3.0.1: {}
 
-  ms@2.1.2: {}
-
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -6323,8 +5818,6 @@ snapshots:
   node-cleanup@2.1.2: {}
 
   node-int64@0.4.0: {}
-
-  node-releases@2.0.13: {}
 
   node-releases@2.0.53: {}
 
@@ -6420,8 +5913,6 @@ snapshots:
   pause-stream@0.0.11:
     dependencies:
       through: 2.3.8
-
-  picocolors@1.0.0: {}
 
   picocolors@1.1.1: {}
 
@@ -6624,10 +6115,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  supports-color@5.5.0:
-    dependencies:
-      has-flag: 3.0.0
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -6670,8 +6157,6 @@ snapshots:
   tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
-
-  to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -6757,12 +6242,6 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
-
-  update-browserslist-db@1.0.11(browserslist@4.21.10):
-    dependencies:
-      browserslist: 4.21.10
-      escalade: 3.1.1
-      picocolors: 1.0.0
 
   update-browserslist-db@1.3.0(browserslist@4.28.7):
     dependencies:


### PR DESCRIPTION
## Summary

Closes the last two Dependabot alerts, and re-lands a change lost to a merge race.

## The babel alerts were real, not stale

I earlier reported `@babel/traverse` and `@babel/core` as absent from the lockfile and wrote that into #1165's description. **That was wrong.** The check I used didn't match quoted lockfile keys, and every `@babel` entry is quoted — so the grep found nothing and I read it as "gone."

They're present, and two vulnerable copies were resolved alongside the current ones:

| Package | Vulnerable | Also present | Needs |
| --- | --- | --- | --- |
| `@babel/traverse` | **7.22.10** (critical) | 7.29.8 | ≥ 7.23.2 |
| `@babel/core` | **7.22.10** (low) | 7.29.7 | ≥ 7.29.6 |

Both arrive via jest — `@jest/transform` and `babel-plugin-istanbul` → `istanbul-lib-instrument@5.2.1` — so they're dev-only, and the fix is the same shape as the other jest stragglers already in `pnpm.overrides`:

```json
"@babel/core@7":     "^7.29.7",
"@babel/traverse@7": "^7.29.8"
```

Within major 7, and the target versions were already in the tree via other parents. After this, no `7.22.10` resolves anywhere.

The hardhat removals from #1165 all hold up under the corrected check — `adm-zip`, `serialize-javascript`, `cookie`, `uuid`, `elliptic`, `ws`, `immutable`, `bn.js`, `secp256k1`, `keccak`, `undici`, `hardhat` are genuinely absent. Only the babel claim was wrong.

## Re-landing the dotenv removal

`dotenv` is still in `main`. The removal was committed to the #1165 branch at **04:54:34**, but #1165 had already been squash-merged at **04:32:45** — so the squash captured only the first commit. The merged commit body still carries the original "left in place" note.

Nothing imports it. `src/transformations/importAgora.ts` reads `process.env` but never imported `dotenv`, so it already relied on the environment being set externally. The Python scripts use `python-dotenv` from `pyproject.toml`, untouched.

## Test plan

Verified with **pnpm 9.15.4**, matching `ci-default.yml`:

- `pnpm install --frozen-lockfile --strict-peer-dependencies` — passes from a clean `node_modules`
- `pnpm build` — passes
- `pnpm lint` — passes
- `pnpm test` — passes
- `pnpm validate` — passes: 117 collections, 7112 projects, 4136 logo files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SCZyNzdYFs5CSRx1LtFQ9