### PR TITLE
chore: pin toolchain and resync generated types

### DIFF
--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -47,13 +47,12 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 9
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]
 
       - name: "Setup Python, Poetry and Dependencies"
-        uses: packetcoders/action-setup-cache-python-poetry@main
+        uses: packetcoders/action-setup-cache-python-poetry@0d0be5577b30d85f3fa2d93a4beeda149520f120 # v1.2.0
         with:
           python-version: 3.12
           poetry-version: 1.8.2

--- a/.github/workflows/setup-external-pr-tools/action.yml
+++ b/.github/workflows/setup-external-pr-tools/action.yml
@@ -12,8 +12,6 @@ runs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v6
-      with:
-        version: 9
 
     - name: Install external-prs CLI
       shell: bash

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "engines": {
     "node": ">=16"
   },
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "build": "pnpm types && tsc",
     "dev": "tsc-watch --onSuccess \"node dist/index.js\"",

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -23,6 +23,7 @@ export interface Project {
   open_collective?: URL[];
   blockchain?: BlockchainAddress[];
   defillama?: URL[];
+  token_coingecko_api_id?: string;
   comments?: string[];
   [k: string]: unknown;
 }
@@ -42,7 +43,6 @@ export interface SocialProfile {
   mirror?: URL[];
   telegram?: URL[];
   twitter?: URL[];
-  [k: string]: unknown;
 }
 /**
  * An address on a blockchain

--- a/src/types/social-profile.ts
+++ b/src/types/social-profile.ts
@@ -14,7 +14,6 @@ export interface SocialProfile {
   mirror?: URL[];
   telegram?: URL[];
   twitter?: URL[];
-  [k: string]: unknown;
 }
 /**
  * A generic URL


### PR DESCRIPTION
## Summary

The last three loose ends from the Dependabot cleanup. Three independent commits, reviewable separately.

### 1. Pin the packetcoders action to a SHA

`packetcoders/action-setup-cache-python-poetry@main` was the only third-party action still tracking a **moving branch**. After #1164 everything else is version-pinned; this one executed whatever upstream happened to push, with no review, and Dependabot can neither flag nor update a branch ref.

Pinned to `0d0be55` — which is what `@main` already resolves to, and is byte-identical to tag `v1.2.0` (last upstream commit 2024-02-29). So this **freezes current behavior rather than changing it**.

### 2. Make `packageManager` the single source of truth for pnpm

The pnpm version lived only in workflow YAML (`version: 9`), with nothing in `package.json`. That gap has a specific failure mode, and it bit me during this work: **pnpm 11 silently ignores `pnpm.overrides` in `package.json`** (it moved the setting to `pnpm-workspace.yaml`). A lockfile regenerated with pnpm 11 therefore drops the security overrides from #1161, passes every local check, and only fails in CI on `--frozen-lockfile`. Nothing warns you.

Adds `"packageManager": "pnpm@9.15.9"` — the version CI already resolves `version: 9` to — and removes the now-redundant `version` inputs from both call sites. Upstream docs: `version` is *"optional when there is a packageManager or devEngines.packageManager field in the package.json"*, and their guidance is to pick one method rather than maintain two that can disagree.

### 3. Resync generated types

`pnpm build` regenerates `src/types/` from `src/resources/schema/`, and the committed output had drifted:

- `Project` gains `token_coingecko_api_id?: string`
- `SocialProfile` loses its `[k: string]: unknown` index signature (the schema sets `additionalProperties: false`)

**No behavior change** — CI regenerates these during `build`, so the published types already match the schema. This only makes the checked-in files honest, so reading them doesn't mislead. Note the `SocialProfile` change is a type *tightening*: it no longer accepts arbitrary keys. That's already true of the published output; it just wasn't visible in the repo.

## Test plan

Verified with **pnpm 9.15.9** — the version this PR pins, resolved via the new `packageManager` field:

- `pnpm install --frozen-lockfile --strict-peer-dependencies` — passes from a clean `node_modules`
- `pnpm build` — passes
- `pnpm lint` — passes
- `pnpm test` — passes
- `pnpm validate` — passes: 117 collections, 7112 projects, 4136 logo files
- All six files under `.github/` parse as YAML (I broke `ci-default.yml` mid-edit by orphaning `run_install` under a deleted `with:`; the parse check caught it, and it's fixed)

CI on this PR is the real test of commits 1 and 2, since both change how the runner sets itself up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SCZyNzdYFs5CSRx1LtFQ9