### PR TITLE
fix(security): close CodeQL findings — url prefix check and token permissions

### DIFF
--- a/.github/workflows/ci-default.yml
+++ b/.github/workflows/ci-default.yml
@@ -5,6 +5,11 @@ env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   DOCKER_PLATFORM: "amd64"
 
+# Least privilege for GITHUB_TOKEN. This job only builds, lints and validates
+# — it never writes back to the repo.
+permissions:
+  contents: read
+
 # Trigger the workflow when:
 on:
   # A push occurs to one of the matched branches.

--- a/.github/workflows/external-prs-handle-comment.yml
+++ b/.github/workflows/external-prs-handle-comment.yml
@@ -6,6 +6,16 @@ env:
   PR_TOOLS_ADMIN_TEAM_NAME: ${{ secrets.PR_TOOLS_ADMIN_TEAM_NAME }}
   PR_TOOLS_REPO: ${{ github.repository }}
 
+# Least privilege for GITHUB_TOKEN. Triggered by issue_comment, so the input is
+# untrusted. Read-only across the board; the CLI's write operations go through
+# the PR_TOOLS GitHub App, not GITHUB_TOKEN.
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  checks: read
+  statuses: read
+
 on:
   issue_comment:
     types:

--- a/.github/workflows/validate-pr-owners.yml
+++ b/.github/workflows/validate-pr-owners.yml
@@ -11,6 +11,17 @@ env:
 
   PR_TOOLS_REPO: ${{ github.repository }}
 
+# Least privilege for GITHUB_TOKEN. This runs on pull_request_target, so the
+# token is the base repo's — it must never be writable from a fork PR.
+# Read-only across the board; the CLI's write operations (check runs, comments)
+# go through the PR_TOOLS GitHub App, not GITHUB_TOKEN.
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  checks: read
+  statuses: read
+
 # Trigger the workflow when:
 on:
   pull_request_target:

--- a/src/transformations/importAgora.ts
+++ b/src/transformations/importAgora.ts
@@ -112,7 +112,7 @@ const agoraToOsoProject = (agoraProj: AgoraProject): Project => {
   const strToUrlObj = (url: string) => ({ url });
   const strArrToUrlArr = (urls: string[]) => urls.map(strToUrlObj);
   const githubUrls = agoraProj.artifacts.filter((x) =>
-    x.startsWith("https://github.com"),
+    x.startsWith("https://github.com/"),
   );
   const npmUrls = agoraProj.artifacts.filter(
     (x) =>


### PR DESCRIPTION
## Summary

Addresses the four CodeQL findings worth acting on. Two others were dismissed as false positives (see below).

### 1. Incomplete URL prefix check — `importAgora.ts:115` (high)

```diff
-  x.startsWith("https://github.com"),
+  x.startsWith("https://github.com/"),
```

Without the trailing slash the check also matches `https://github.com.evil.com/foo`, so a hostile artifact URL would be filed as a GitHub repo. The npm check three lines below already uses trailing slashes — this was an inconsistency, not a deliberate choice.

Impact is bounded: it's an Agora data-import transform, so the worst case is a mis-filed URL in a project YAML. No code execution.

### 2. Missing workflow permissions — 3 workflows (medium)

Added explicit top-level `permissions:` blocks.

**This isn't purely additive, and that's worth reviewing.** The repo default is currently `default_workflow_permissions=read` — read on *every* scope — and an explicit block sets unlisted scopes to `none`. So a too-narrow block is a behavior change, not just hardening.

| Workflow | Granted | Why |
| --- | --- | --- |
| `ci-default.yml` | `contents: read` | only builds, lints, validates; never writes back |
| `validate-pr-owners.yml` | `contents`, `pull-requests`, `issues`, `checks`, `statuses` — all read | `pull_request_target`, so the token is the base repo's |
| `external-prs-handle-comment.yml` | same read set | `issue_comment`, so the input is untrusted |

For the two external-PR workflows I enumerated the read scopes the `external-prs` CLI could plausibly use rather than the single narrowest one — guessing too tight would break external PR validation, which is this repo's most important workflow. No write scope is needed anywhere: the CLI's writes (check runs, comments) go through the `PR_TOOLS` GitHub App, not `GITHUB_TOKEN`.

**The value is defense in depth.** There's no exposure today — the default is already read. But if the org or repo default is ever flipped to write, all three would silently gain write access, including two reachable by external contributors. Now they can't.

## Dismissed as false positives

Alerts **#4** and **#5**, `py/incomplete-url-substring-sanitization` at `packages_csv.py:16` and `:44`:

```python
name.startswith("github.com/")
```

These aren't URLs — they're **Go module paths**, which legitimately begin with `github.com/`. `str.startswith` is anchored, so `evil-github.com/x` doesn't match. The rule targets spoofable URL host checks; the code is correct as written.

## Also checked, no change needed

I looked at `validate-pr-owners.yml`'s `pull_request_target` usage, since that trigger plus secrets is the classic pwn-request shape and CodeQL doesn't flag it. **It's implemented correctly:** it checks out the *base* repo into `./main`, runs only base-repo composite actions, installs the CLI from npm, and checks the PR head into `./pr` where it's consumed as **data**. No `pnpm install` runs inside `./pr`, so no PR lifecycle scripts execute.

One hygiene note, not a vulnerability and not changed here: `${{ github.event.pull_request.user.login }}` is interpolated directly into two `run:` blocks. GitHub usernames are `[A-Za-z0-9-]` so it isn't injectable, but convention is to pass such values via `env:`.

## Test plan

- All six files under `.github/` parse as YAML, with the `permissions` blocks confirmed present and correct
- `pnpm build`, `pnpm lint`, `pnpm validate` — pass (117 collections, 7112 projects, 4136 logo files)
- **CI on this PR is the real test of the permissions change** — `validate-pr-owners` runs on `pull_request_target`, so it exercises the new block directly. `external-prs-handle-comment` only fires on `issue_comment` and will *not* be exercised here; if it misbehaves later, widening its read scopes is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SCZyNzdYFs5CSRx1LtFQ9