### PR TITLE
hotfix(ci): restore explicit pnpm version for external PR tooling

### DIFF
--- a/.github/workflows/setup-external-pr-tools/action.yml
+++ b/.github/workflows/setup-external-pr-tools/action.yml
@@ -12,6 +12,14 @@ runs:
 
     - name: Setup pnpm
       uses: pnpm/action-setup@v6
+      with:
+        # An explicit version is required here, and packageManager cannot
+        # replace it. Callers of this composite check the repo out into ./main,
+        # so there is no package.json at the workspace root for action-setup to
+        # read. This step also installs a standalone CLI from npm rather than
+        # operating on this repo, so it has no package.json context at all.
+        # Keep in sync with the packageManager field in package.json.
+        version: 9.15.9
 
     - name: Install external-prs CLI
       shell: bash


### PR DESCRIPTION
## This is a live break on main

Every community PR currently fails at **Setup external pr tools**:

```
Error: No pnpm version is specified.
Please specify it by one of the following ways:
  - in the GitHub Action config with the key "version"
  - in the package.json with the key "packageManager"
```

Introduced by #1167 (mine). External PR validation has been down since it merged at 21:15.

## Cause

#1167 removed `version: 9` from `setup-external-pr-tools/action.yml`, on the assumption that the new `packageManager` field in `package.json` would cover it. It can't, for two independent reasons:

1. **Both callers check the repo out into `./main`** (`validate-pr-owners.yml:38`, `external-prs-handle-comment.yml:32`), so there is no `package.json` at the workspace root for `action-setup` to read.
2. **This step installs a standalone CLI from npm** (`pnpm add @opensource-observer/ops-external-prs`) rather than operating on this repo — so it has no `package.json` context to fall back on at all.

`ci-default.yml` is unaffected: it checks out at the root, where `packageManager` resolves normally. That asymmetry is why the rest of CI stayed green.

## Why #1167's own CI didn't catch it

`pull_request_target` runs the workflow definition from the **base branch**, not the PR. When #1167 was tested, main still had `version: 9` in this composite, so its `Validate PR` check exercised the old, working copy. The change was structurally incapable of failing its own PR — only merging it could expose the fault.

Worth remembering for any future edit to these three workflows: **a `pull_request_target` workflow cannot test changes to itself.**

## Fix

Restore an explicit version, pinned to `9.15.9` to match `packageManager` (rather than the looser `9` it had before), with a comment explaining why `packageManager` can't serve this call site.

This is a narrow retreat from #1167's single-source-of-truth goal, and the right one: the field genuinely cannot reach a composite action that runs outside the repo checkout. `ci-default` still derives its version solely from `packageManager`.

## Test plan

- All six `.github/` YAML files parse
- Verified both callers of this composite use the `./main` checkout path, so one fix covers both
- Verified `validate/action.yml` has no `action-setup` of its own — it inherits from this step, so it's covered too
- **The real test is `Validate PR` on this PR.** Unlike #1167, this one *is* testable: the composite is loaded from `./main/...` at the base branch, so a green check here still leaves the merge unproven. Recommend confirming on the next community PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SCZyNzdYFs5CSRx1LtFQ9