### PR TITLE
Add Open Multi-Agent project

### DIFF
--- a/data/projects/o/open-multi-agent.yaml
+++ b/data/projects/o/open-multi-agent.yaml
@@ -1,0 +1,12 @@
+version: 7
+name: open-multi-agent
+display_name: Open Multi-Agent
+description: Open-source infrastructure for controlled, inspectable agent teams, with TypeScript-native dynamic task-DAG orchestration, approvals, tracing, evaluation, checkpointing, and resume support.
+websites:
+  - url: https://open-multi-agent.com
+github:
+  - url: https://github.com/open-multi-agent/open-multi-agent
+npm:
+  - url: https://www.npmjs.com/package/@open-multi-agent/core
+  - url: https://www.npmjs.com/package/@open-multi-agent/otel
+  - url: https://www.npmjs.com/package/create-oma-app


### PR DESCRIPTION
## Summary

Add Open Multi-Agent to `oss-directory` using the current version 7 project schema.

The entry points to the project's canonical website and GitHub repository, and lists its three published npm packages.

## Source verification

- Repository: https://github.com/open-multi-agent/open-multi-agent
- Website: https://open-multi-agent.com
- npm: `@open-multi-agent/core`, `@open-multi-agent/otel`, and `create-oma-app`
- License: MIT

## Validation

- `pnpm lint`
- `pnpm validate` — 117 collections, 7,113 projects, and 4,136 logo files validated
- `git diff --check`

Disclosure: I maintain Open Multi-Agent.
