### PR TITLE
fix(data): kerne description cites an audit as upcoming that published 2026-07-31, and the listed PSM is the retired one

### DIFF
--- a/data/projects/k/kerne.yaml
+++ b/data/projects/k/kerne.yaml
@@ -1,7 +1,7 @@
 version: 7
 name: kerne
 display_name: Kerne
-description: Kerne is a delta-neutral synthetic dollar protocol on Base. kUSD is minted 1:1 against USDC through an on-chain Peg Stability Module, and skUSD is the staked, yield-bearing ERC-4626 wrapper. The strategy runs a delta-neutral basis trade hedged on Hyperliquid. Kerne publishes an hourly signed proof of reserves that anyone can recompute in their own browser, and has engaged Hexens for its first external smart-contract audit (fieldwork begins 2026-07-13).
+description: Kerne is a delta-neutral synthetic dollar protocol on Base. kUSD is minted 1:1 against USDC through an on-chain Peg Stability Module, and skUSD is the staked, yield-bearing ERC-4626 wrapper. The strategy runs a delta-neutral basis trade hedged on Hyperliquid. Kerne publishes an hourly signed proof of reserves that anyone can recompute in their own browser. Its first external smart-contract audit, by Hexens, was published on 2026-07-31 (10 findings, 0 critical, 2 high; 8 fixed in source and 2 acknowledged by design). Kerne separately publishes the places where its deployed bytecode still differs from current source at kerne.fi/security/deployed-vs-source.
 websites:
   - url: https://kerne.fi/
 social:
@@ -43,12 +43,24 @@ blockchain:
     tags:
       - contract
     name: skUSD (staked kUSD, ERC-4626)
+  - address: "0xabde1138aa1ce88d1df06422c0c3b05d70569803"
+    networks:
+      - base
+    tags:
+      - contract
+    name: KUSDPSM v3 (live mint module, sole holder of kUSD MINTER_ROLE)
   - address: "0x07ebb486e11bd217e6085eb5ab663e4517595993"
     networks:
       - base
     tags:
       - contract
-    name: KUSDPSM v3 (Peg Stability Module)
+    name: KUSDPSM v3 (retired mint module, MINTER_ROLE revoked 2026-07-13, still holds reserve)
+  - address: "0xff3025ec18e301855ab0f36ec6eca115a29a5fbc"
+    networks:
+      - base
+    tags:
+      - contract
+    name: KUSDPSM (redeem reserve module, pre-v3 build)
   - address: "0x8ccc56b5624e2fdb592f6609d81f4c3798e3292b"
     networks:
       - base


### PR DESCRIPTION
Two corrections to `data/projects/k/kerne.yaml`. I work on Kerne, and both of these are stale values I supplied myself in #1112.

### 1. The description described the audit as upcoming. It published two weeks ago.

The record still reads *"has engaged Hexens for its first external smart-contract audit (fieldwork begins 2026-07-13)"*. The Hexens report published **2026-07-31** and is public at https://hexens.io/audit-reports/kerne-protocol-july-2026 (10 findings, 0 critical, 2 high, 8 fixed in source and 2 acknowledged by design).

I have written "8 fixed **in source**" deliberately. Kerne's live vault bytecode predates those fixes, so a reader who takes "8 fixed" to mean "fixed on chain" would be misled. The replacement text points at https://kerne.fi/security/deployed-vs-source, which is where Kerne states that gap.

### 2. The listed Peg Stability Module is the retired one.

`0x07eBb486e11bd217e6085eb5ab663e4517595993` was labelled `KUSDPSM v3 (Peg Stability Module)`. It is no longer the mint path: it lost `MINTER_ROLE` on kUSD on **2026-07-13**, and the record has named it as the module ever since.

Verifiable in one call each, on Base:

```bash
KUSD=0x5C2EfdF0D8D286959b42308966bc2B97f5680AA3
MINTER=0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6
RPC=https://mainnet.base.org

cast call $KUSD "hasRole(bytes32,address)(bool)" $MINTER 0xaBDE1138aa1Ce88d1dF06422C0c3b05D70569803 --rpc-url $RPC  # true
cast call $KUSD "hasRole(bytes32,address)(bool)" $MINTER 0x07eBb486e11BD217e6085eb5ab663e4517595993 --rpc-url $RPC  # false
```

The role transfer is two adjacent transactions in block range 48591869 to 48591914:

| event | block | timestamp | tx |
|---|---|---|---|
| `RoleGranted` MINTER_ROLE to `0xaBDE1138` | 48591869 | 2026-07-13 20:04:45Z | `0xcfde847381a64f1c061b8b6fd07574c0a0cd53a7c6d0a08ff1e99856bebd6e0b` |
| `RoleRevoked` MINTER_ROLE from `0x07eBb486` | 48591914 | 2026-07-13 20:06:15Z | `0xb83f61a6c856265b55d0ca63d1dcda5416b29d4d181d5cfa987c53198d5b5f60` |

This PR adds `0xaBDE1138` as the live mint module and relabels `0x07eBb486` as retired. It does not remove `0x07eBb486`, because that module still holds 995.003 USDC of the reserve and is still worth monitoring.

It also adds the third module, `0xFf3025ec18e301855ab0f36ec6eca115a29a5fbc`, which holds 85.885006 USDC of reserve. Listing two of the three modules while omitting the one that holds a live balance seemed like the wrong record to leave behind. All three are source-verified on Blockscout and BaseScan.

### Checks

- Validates against `src/resources/schema/project.json` and `blockchain-address.json`. Only enum tags are used, and `contract` is the only tag added.
- Neither new address appears anywhere else in `data/`.
- One file changed, `+14 / -2`. No other project touched.
- Every figure above read live on 2026-08-13 at Base block 49929908.
