### PR TITLE
Add Codex Quota Overlay

### DIFF
--- a/data/projects/c/codex-quota-overlay.yaml
+++ b/data/projects/c/codex-quota-overlay.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: codex-quota-overlay
+display_name: Codex Quota Overlay
+description: Privacy-friendly quota and reset-time overlay for Codex Desktop.
+websites:
+  - url: https://github.com/cpys/codex-quota-overlay
+github:
+  - url: https://github.com/cpys/codex-quota-overlay


### PR DESCRIPTION
This PR adds Codex Quota Overlay to the OSS Directory.

- Project: https://github.com/cpys/codex-quota-overlay
- MIT-licensed, independent community project; I am its maintainer.
- The entry uses the repository as both the public website and GitHub artifact.

This is a factual directory submission; there is no paid placement or vote request.