### PR TITLE
Add SandBase CLI

### DIFF
--- a/data/projects/c/cli-sandbaseai.yaml
+++ b/data/projects/c/cli-sandbaseai.yaml
@@ -1,0 +1,13 @@
+version: 7
+name: cli-sandbaseai
+display_name: SandBase CLI
+description: Open-source CLI and local MCP bridge that connects AI agents to 2,000+ AI models through one account.
+websites:
+  - url: https://www.sandbase.ai
+social:
+  twitter:
+    - url: https://twitter.com/SandbaseAI
+github:
+  - url: https://github.com/sandbaseai/cli
+npm:
+  - url: https://www.npmjs.com/package/@sandbaseai/cli


### PR DESCRIPTION
## Summary

Adds SandBase CLI as a structured open-source project with its official GitHub repository, website, X account, and npm package. SandBase CLI is an open-source CLI and local MCP bridge that connects AI agents to 2,000+ AI models through one account.

## Validation

- `pnpm run validate`
- `pnpm lint`
- `git diff --check`

Disclosure: I am affiliated with SandBase, and this submission was prepared with AI assistance.