### PR TITLE
Add Codex Quota Overlay to the OSS Directory

### DIFF
--- a/data/projects/c/codex-quota-overlay-cpys.yaml
+++ b/data/projects/c/codex-quota-overlay-cpys.yaml
@@ -1,0 +1,10 @@
+version: 7
+name: codex-quota-overlay-cpys
+display_name: Codex Quota Overlay
+description: Privacy-friendly Codex Desktop quota overlay for Windows and macOS.
+websites:
+  - url: https://cpys.github.io/codex-quota-overlay/
+github:
+  - url: https://github.com/cpys/codex-quota-overlay
+comments:
+  - Independent community project; not affiliated with or endorsed by OpenAI.


### PR DESCRIPTION
Adds one factual project entry for Codex Quota Overlay. The project is an independent community-maintained Windows/macOS desktop overlay and is not affiliated with or endorsed by OpenAI. Public links: https://github.com/cpys/codex-quota-overlay and https://cpys.github.io/codex-quota-overlay/. The entry follows schema version 7 and was checked with the repository YAML parser. Full pnpm validation was not run to completion because the local dependency install requires approval for an ignored es5-ext build script.