### PR TITLE
Add Production Readiness Checklist

### DIFF
--- a/data/projects/p/production-readiness-checklist-marinjursic.yaml
+++ b/data/projects/p/production-readiness-checklist-marinjursic.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: production-readiness-checklist-marinjursic
+display_name: Production Readiness Checklist
+description:
+  Production Readiness Checklist is an open source, technology-neutral knowledge
+  base for reviewing architecture, APIs, data, security, testing, delivery, reliability,
+  observability, accessibility, privacy, and incident response before release.
+websites:
+  - url: https://marinjursic.github.io/production-readiness-checklist/
+github:
+  - url: https://github.com/MarinJursic/production-readiness-checklist


### PR DESCRIPTION
## What

Adds the Production Readiness Checklist as a new OSS Directory project.

## Why

I maintain this free, MIT-licensed project. It is an evidence-driven, technology-neutral knowledge base for reviewing architecture, APIs, data, security, testing, delivery, reliability, observability, accessibility, privacy, incident response, and other release concerns.

## Project details

- Project slug: `production-readiness-checklist-marinjursic`
- Website: https://marinjursic.github.io/production-readiness-checklist/
- GitHub: https://github.com/MarinJursic/production-readiness-checklist

## Checks

- Confirmed the project name, display name, and GitHub URL are not already indexed
- Used schema version 7 and the single-repository naming convention
- `pnpm start validate-projects --dir ./data/projects/p` passed for 428 projects
- `pnpm exec prettier --check data/projects/p/production-readiness-checklist-marinjursic.yaml` passed
- `git diff --check` passed

The full `pnpm run validate` currently stops on an existing duplicate GitHub URL shared by `thales.yaml` and `overtime.yaml`. The full `pnpm lint` also reports pre-existing formatting warnings in six unrelated project files; this new file passes Prettier independently.
