### PR TITLE
Add Accumulator Reality Check project

### DIFF
--- a/data/projects/a/accumulator-reality-check-licensedbets-open.yaml
+++ b/data/projects/a/accumulator-reality-check-licensedbets-open.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: accumulator-reality-check-licensedbets-open
+display_name: Accumulator Reality Check
+description: MIT-licensed JavaScript library explaining how bookmaker margin compounds across accumulator legs.
+websites:
+  - url: https://licensedbets.co.za/accumulator/
+github:
+  - url: https://github.com/licensedbets-open/accumulator-reality-check


### PR DESCRIPTION
Adds Accumulator Reality Check as a single-repository MIT-licensed JavaScript project.

Artifacts:
- exact public calculator website
- canonical GitHub repository

The project is educational consumer maths and does not provide odds, tips, market data, or predictions.