### PR TITLE
Fix prettier formatting on five project descriptions

### DIFF
--- a/data/projects/c/cometbridge.yaml
+++ b/data/projects/c/cometbridge.yaml
@@ -1,7 +1,8 @@
 version: 7
 name: cometbridge
 display_name: Comet Protocol
-description: Comet Protocol is a cross-chain communication aggregator that routes
+description:
+  Comet Protocol is a cross-chain communication aggregator that routes
   asset transfers and messages between Ethereum, Bitcoin and other Layer 1 and Layer
   2 networks through a single bridge contract deployed on each supported chain.
 websites:

--- a/data/projects/j/jasmine-energy.yaml
+++ b/data/projects/j/jasmine-energy.yaml
@@ -1,7 +1,8 @@
 version: 7
 name: jasmine-energy
 display_name: Jasmine Energy
-description: Jasmine Energy builds tokenized renewable energy infrastructure, automating
+description:
+  Jasmine Energy builds tokenized renewable energy infrastructure, automating
   permitting, incentives, and tracking for the solar energy industry. Its on-chain pools
   wrap Energy Attribute Certificates (EACs) so they can be traded and retired programmatically,
   with a retirement service for permanently consuming certificates.

--- a/data/projects/m/mach-exchange.yaml
+++ b/data/projects/m/mach-exchange.yaml
@@ -1,7 +1,8 @@
 version: 7
 name: mach-exchange
 display_name: Mach
-description: Mach is an intents-based cross-chain DEX built by Tristero Research. It settles
+description:
+  Mach is an intents-based cross-chain DEX built by Tristero Research. It settles
   swaps between chains using an optimistic escrow contract deployed on each supported network,
   with LayerZero for cross-chain messaging, so trades fill without waiting for a canonical
   bridge.

--- a/data/projects/p/polyflip.yaml
+++ b/data/projects/p/polyflip.yaml
@@ -1,7 +1,8 @@
 version: 7
 name: polyflip
 display_name: Polyflip
-description: Polyflip is a decentralized casino on Polygon, offering coinflip, crash,
+description:
+  Polyflip is a decentralized casino on Polygon, offering coinflip, crash,
   roulette and related games settled on-chain. Holders of the Polyflip NFT act as the house
   and receive a share of game profits, with the treasury and each game deployed as separate
   public contracts.

--- a/data/projects/y/yup-io.yaml
+++ b/data/projects/y/yup-io.yaml
@@ -1,7 +1,8 @@
 version: 7
 name: yup-io
 display_name: Yup
-description: Yup is a social network for curators, where users curate and rate content
+description:
+  Yup is a social network for curators, where users curate and rate content
   across the web and earn based on the influence of their curation. The YUP token backing
   the protocol is deployed on Ethereum, Polygon and Base.
 websites:


### PR DESCRIPTION
`lint:prettier` has been failing on `main` for every open PR. All five offending files came from my earlier PRs, so this cleans up after myself.

| File | Added by |
|---|---|
| `data/projects/j/jasmine-energy.yaml` | #1171 |
| `data/projects/m/mach-exchange.yaml` | #1172 |
| `data/projects/p/polyflip.yaml` | #1173 |
| `data/projects/y/yup-io.yaml` | #1175 |
| `data/projects/c/cometbridge.yaml` | #1178 |

### The defect

Identical in all five: a multi-line plain scalar that begins on the `description:` line. Prettier requires it to begin on the following line.

```diff
-description: Comet Protocol is a cross-chain communication aggregator that routes
+description:
+  Comet Protocol is a cross-chain communication aggregator that routes
   asset transfers and messages between Ethereum, Bitcoin and other Layer 1 and Layer
   2 networks through a single bridge contract deployed on each supported chain.
```

That one-line split is the entire change in each file — five files, +10/-5.

### Formatting only

Produced with `prettier@3.9.6 --write` (matching the pinned version in `package.json`), then verified that every file's parsed YAML is unchanged:

```
SAME  data/projects/c/cometbridge.yaml
SAME  data/projects/j/jasmine-energy.yaml
SAME  data/projects/m/mach-exchange.yaml
SAME  data/projects/p/polyflip.yaml
SAME  data/projects/y/yup-io.yaml
all semantically identical: True
```

No project data, addresses, URLs or descriptions change — `description` parses to the identical string either way.

### Remaining

After this, `prettier --check` over `data/**/*.yaml` reports one file left: `data/projects/o/overtime.yaml`, which #1190 deletes. Merging both leaves `test (node)` green.
