### PR TITLE
Add Payload Components

### DIFF
--- a/data/logos/p/payload-components-ducksss.svg
+++ b/data/logos/p/payload-components-ducksss.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="1000" viewBox="0 0 24 24"><rect width="24" height="24" fill="#059669" rx="6"/><rect width="8.4" height="8.4" x="4.8" y="4.8" fill="#fff" rx="1.9"/><rect width="8.4" height="8.4" x="10.8" y="10.8" fill="#fff" rx="1.9"/></svg>

--- a/data/projects/p/payload-components-ducksss.yaml
+++ b/data/projects/p/payload-components-ducksss.yaml
@@ -1,0 +1,12 @@
+version: 7
+name: payload-components-ducksss
+display_name: Payload Components
+description:
+  An MIT, community-first registry and CLI that installs typed Payload CMS
+  blocks into Payload v3 and Next.js projects, including the required wiring.
+websites:
+  - url: https://www.payload-components.xyz
+github:
+  - url: https://github.com/Ducksss/payload-components
+npm:
+  - url: https://www.npmjs.com/package/payload-components


### PR DESCRIPTION
## What changed

- add Payload Components as `payload-components-ducksss`
- register its canonical website, GitHub repository, and npm package
- include the project's canonical current SVG logo

## Why

Payload Components is an MIT, community-first registry and CLI for installing
typed Payload CMS blocks into Payload v3 and Next.js projects. In addition to
copying source files, its CLI wires the Pages collection, `RenderBlocks`,
generated Payload types, and the admin import map while leaving a reviewable
git diff.

I maintain the project. This entry makes its repository and npm artifact
discoverable through the OSS Directory.

## Validation

- `pnpm run validate`
- `pnpm lint`

Project: https://www.payload-components.xyz

