### PR TITLE
Add NixieFX project

### DIFF
--- a/data/projects/n/nixie-fx-azakhary.yaml
+++ b/data/projects/n/nixie-fx-azakhary.yaml
@@ -1,0 +1,7 @@
+name: nixie-fx-azakhary
+display_name: NixieFX
+description: Open-source runtime for particle effects authored with the NixieFX editor, with renderer adapters for PixiJS and Three.js.
+github:
+  - url: https://github.com/azakhary/nixie-fx
+npm:
+  - url: https://www.npmjs.com/package/nixie-fx


### PR DESCRIPTION
Adds NixieFX, an open-source runtime for particle effects with PixiJS and Three.js renderer adapters.

Website: https://nixiefx.com/
Repository: https://github.com/azakhary/nixie-fx
npm: https://www.npmjs.com/package/nixie-fx
License: MIT