### PR TITLE
Add WebSSH project

### DIFF
--- a/data/projects/w/webssh-bifrost0x.yaml
+++ b/data/projects/w/webssh-bifrost0x.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: webssh-bifrost0x
+display_name: WebSSH
+description: Security-focused, self-hosted SSH and SFTP workspace for homelabs and teams.
+websites:
+  - url: https://bifrost0x.github.io/webssh/
+github:
+  - url: https://github.com/bifrost0x/webssh


### PR DESCRIPTION
**Title:** Add WebSSH to OSS Directory

Adds [[WebSSH](https://github.com/bifrost0x/webssh)](https://github.com/bifrost0x/webssh) to the OSS Directory.

WebSSH is a security-focused, self-hosted SSH and SFTP workspace for homelabs and teams. It provides browser-based SSH terminals and SFTP access with features including multi-user support, encrypted SSH key storage, passkeys/WebAuthn, OIDC, LDAP/AD, audit logging, host-key verification, persistent sessions, and Docker deployment.

This PR adds the project using the current v7 schema with the GitHub repository and project website.

Disclosure: I am the maintainer of WebSSH.