### PR TITLE
Add gbc-astro to OSS Directory

### DIFF
--- a/data/projects/g/gbc-astro-engine-getbirthchart-com.yaml
+++ b/data/projects/g/gbc-astro-engine-getbirthchart-com.yaml
@@ -1,0 +1,10 @@
+version: 7
+name: gbc-astro-engine-getbirthchart-com
+display_name: gbc-astro
+description: Open-source Python astrology calculation engine built with Swiss Ephemeris.
+websites:
+  - url: https://getbirthchart.com
+github:
+  - url: https://github.com/getbirthchart-com/gbc-astro-engine
+pypi:
+  - url: https://pypi.org/project/gbc-astro


### PR DESCRIPTION
Adds gbc-astro, an open-source Python astrology calculation engine built with Swiss Ephemeris and maintained by GetBirthChart.