### PR TITLE
Add SEMAPRAX project

### DIFF
--- a/data/projects/s/semaprax-wavect.yaml
+++ b/data/projects/s/semaprax-wavect.yaml
@@ -1,0 +1,10 @@
+version: 7
+name: semaprax-wavect
+display_name: SEMAPRAX
+description:
+  Experimental agent-native systems programming language with deterministic
+  semantic graphs, verified patches, and native and WebAssembly compiler lanes.
+websites:
+  - url: https://wavect.io/semaprax/
+github:
+  - url: https://github.com/wavect/semaprax


### PR DESCRIPTION
Adds SEMAPRAX as a single-repository open-source project, with its public research page and canonical GitHub repository as artifacts. The description deliberately identifies the project as experimental.\n\nDisclosure: I am submitting this on behalf of Wavect GmbH, the organization developing SEMAPRAX.