### PR TITLE
Add AI Model Prompt Brief Builder

### DIFF
--- a/data/projects/a/ai-model-prompt-brief-builder-mr-zhangbo.yaml
+++ b/data/projects/a/ai-model-prompt-brief-builder-mr-zhangbo.yaml
@@ -1,0 +1,5 @@
+version: 7
+name: ai-model-prompt-brief-builder-mr-zhangbo
+display_name: AI Model Prompt Brief Builder
+github:
+  - url: https://github.com/Mr-ZhangBo/ai-model-prompt-brief-builder


### PR DESCRIPTION
## Summary

- add AI Model Prompt Brief Builder to the OSS Directory
- use the version 7 project schema and the naming convention for a personal GitHub repository
- link the public MIT-licensed source repository

## Validation

- `pnpm validate:projects` — passed; validated 7,127 projects
- `pnpm exec prettier --check data/projects/a/ai-model-prompt-brief-builder-mr-zhangbo.yaml` — passed
