### PR TITLE
Add Possum Finance (possum-finance)

### DIFF
--- a/data/projects/p/possum-finance.yaml
+++ b/data/projects/p/possum-finance.yaml
@@ -1,0 +1,12 @@
+version: 7
+name: possum-finance
+display_name: Possum Finance
+description:
+  Possum Finance builds TopCut, a prediction market where traders submit price forecasts
+  for a fixed cohort and the closest predictions share the pot.
+  Each market round is its own contract, settled through a shared vault.
+websites:
+  - url: https://www.possum.finance
+social:
+  twitter:
+    - url: https://x.com/Possum_Finance


### PR DESCRIPTION
Adds Possum Finance, which builds the TopCut prediction market on Arbitrum One.

- Website: https://www.possum.finance
- Twitter: https://x.com/Possum_Finance

Slug is domain-derived. The team publishes under two brands: the GitHub account is a personal User, `PossumLabsCrypto`, with blog `possumlabs.io` and handle @Possum_Labs, while the product site is `possum.finance` with handle @Possum_Finance. I have used the product site's own details and omitted `github:` rather than assert a personal account as the project's org.

No logo is included: the only first-party image on the site is a 36x36 favicon, which would be visibly degraded at 400x400, and the other candidate is a wide OG banner rather than a square mark. Happy to add one if the team has a better asset.

No existing project references `possum.finance` or this slug.

Deployed contracts on Arbitrum One (evidence; source `PossumLabsCrypto/topcut-subgraph` `networks.json`, key `arbitrum-one`):

| Contract | Address |
|---|---|
| TopCutVault | `0x3cfc3CBA1B4aAF969057F590D23efe46848F4270` |
| TopCutNFT | `0xFbEc13381B63E811538F63177CfD2B5FF925e88b` |
| BTC_TopCutMarket1 | `0x9A5f16c1f2d6b8c9530144aD23Cfa9B3c4717eF1` |
| BTC_TopCutMarket2 | `0x8B64Cf63B08f7eB3ad163282bf61d382DfFF0586` |
| BTC_TopCutMarket3 | `0x10EF281AAc569Cb011BfcB4e1C6cA490011486a5` |
| BTC_TopCutMarket4 | `0xB8eC8622D8B7924337CA7B143683459fE5a13f79` |
| BTC_TopCutMarket5 | `0xE8B9a818D57E2413E05144311E2d4d190c3f711c` |

All seven verified to hold bytecode on Arbitrum One. The sibling `PossumFinanceSubgraph` repo has an identically shaped file keyed `arbitrum-sepolia` and is deliberately not used.