### PR TITLE
Add SandBase Harness to the OSS Directory

### DIFF
--- a/data/projects/s/sandbase-harness.yaml
+++ b/data/projects/s/sandbase-harness.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: sandbase-harness
+display_name: SandBase Harness
+description: Local-first, self-hosted AI agent runtime with MCP tools, sandboxed sessions, memory, credentials, audit, and replay.
+github:
+  - url: https://github.com/sandbaseai/sandbase-harness
+websites:
+  - url: https://github.com/sandbaseai/sandbase-harness


### PR DESCRIPTION
## Summary
- add the public SandBase Harness repository to the OSS Directory
- include factual project metadata and GitHub source link

## Validation
- `pnpm validate:projects`
- `git diff --check`

SandBase Harness is Apache-2.0 licensed and provides a local-first, self-hosted AI agent runtime with MCP tools, sandboxed sessions, memory, credentials, audit, and replay.
