### PR TITLE
Add Authier to the OSS Directory

### DIFF
--- a/data/projects/a/authier-pm.yaml
+++ b/data/projects/a/authier-pm.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: authier-pm
+display_name: Authier
+description: An open-source password manager for credentials and TOTP codes, with client-side encrypted sync and trusted-device approval.
+websites:
+  - url: https://www.authier.pm
+social:
+  twitter:
+    - url: https://twitter.com/authierpm
+github:
+  - url: https://github.com/authier-pm


### PR DESCRIPTION
## Summary

- add Authier as the `authier-pm` project, following the dedicated GitHub organization naming rule
- register its canonical website, GitHub organization, and public social profile
- describe the password manager's client-side encrypted sync and trusted-device approval

I maintain Authier and am submitting this project with that affiliation disclosed.

## Validation

- `pnpm run validate`
- `pnpm lint`
- `git diff --check`
