### PR TITLE
Add Folklore and Noodle biomedical MCP projects

### DIFF
--- a/data/projects/f/folklore-mcp-helena-bioinformatics.yaml
+++ b/data/projects/f/folklore-mcp-helena-bioinformatics.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: folklore-mcp-helena-bioinformatics
+display_name: Folklore Clinical Variant Interpretation MCP
+description: Folklore provides evidence-backed interpretation of supported GRCh38 germline variants under ACMG/AMP, with structured public evidence, provenance, and literature for professional review.
+websites:
+  - url: https://folklore.helena.bio
+github:
+  - url: https://github.com/helena-bioinformatics/folklore-mcp

--- a/data/projects/n/noodle-mcp-helena-bioinformatics.yaml
+++ b/data/projects/n/noodle-mcp-helena-bioinformatics.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: noodle-mcp-helena-bioinformatics
+display_name: Noodle Biomedical Literature Discovery MCP
+description: Noodle provides biomedical literature search, publication details, and bounded citation and semantic graph traversal over public research metadata.
+websites:
+  - url: https://noodle.helena.bio
+github:
+  - url: https://github.com/helena-bioinformatics/noodle-mcp


### PR DESCRIPTION
Adds two Apache-2.0 open source MCP projects from Helena Bioinformatics:

1. Folklore Clinical Variant Interpretation MCP, for evidence-backed interpretation of supported GRCh38 germline variants under ACMG/AMP, with structured public evidence and provenance.
2. Noodle Biomedical Literature Discovery MCP, for biomedical literature search and bounded citation and semantic graph traversal over public research metadata.

Each record includes the canonical product website and GitHub repository. The project names follow the single-repository naming pattern in the OSS Directory documentation.