### PR TITLE
Add twofold project

### DIFF
--- a/data/projects/t/twofold.yaml
+++ b/data/projects/t/twofold.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: twofold
+display_name: Twofold
+description: Twofold is a DeFi liquidity protocol on Robinhood Chain. TWO is its native token, used for staking and governance signaling. Deposits provide two-sided liquidity to Uniswap v4 pools through the DualPool hook, and protocol fees fund streaming staking rewards.
+websites:
+  - url: https://twofold.fi
+social:
+  twitter:
+    - url: https://x.com/twofoldfi
+github:
+  - url: https://github.com/twofoldfi


### PR DESCRIPTION
Project registration for Twofold, a DeFi liquidity protocol live on Robinhood Chain (chain id 4663). Website: https://twofold.fi. TWO token contract: 0x2A4a33A2163D005d8E7f1D9aC08d14c98db288d5 (robinhoodchain.blockscout.com). Adds data/projects/t/twofold.yaml so `twofold` becomes a valid owner_project slug for OLI labels.