### PR TITLE
Add Strata (strata-markets)

### DIFF
--- a/data/projects/s/strata-markets.yaml
+++ b/data/projects/s/strata-markets.yaml
@@ -1,0 +1,60 @@
+version: 7
+name: strata-markets
+display_name: Strata
+description: Strata is a structured-yield protocol that splits the return of a yield-bearing asset into two tokenized tranches — a senior tranche (srTOKEN) taking a fixed, protected yield and a junior tranche (jrTOKEN) taking the variable remainder — so depositors can pick a risk-reward profile instead of accepting a single blended rate. Markets run on Ethereum over Ethena USDe, Neutrl NUSD, Midas mHYPER and mM1-USD, Saturn USDat, Hastra PRIME and Nest nOPAL.
+websites:
+  - url: https://strata.markets
+social:
+  twitter:
+    - url: https://x.com/strata_markets
+github:
+  - url: https://github.com/Strata-Markets
+blockchain:
+  - address: "0x3d7d6fdf07ee548b939a80edbc9b2256d0cdc003"
+    name: srUSDe
+    networks:
+      - mainnet
+    tags:
+      - contract
+  - address: "0xc58d044404d8b14e953c115e67823784dea53d8f"
+    name: jrUSDe
+    networks:
+      - mainnet
+    tags:
+      - contract
+  - address: "0x908b3921aae4fc17191d382bb61020f2ee6c0e20"
+    name: StrataCDO
+    networks:
+      - mainnet
+    tags:
+      - contract
+  - address: "0x1d19e18ecac4ef332a0d5d6aa3a0f0f772605f60"
+    name: AccessControlManager
+    networks:
+      - mainnet
+    tags:
+      - contract
+  - address: "0xa27ca9292268ee0f0258b749f1d5740c9bb68b50"
+    name: Admin Multisig (3/4)
+    networks:
+      - mainnet
+    tags:
+      - safe
+  - address: "0x4be3749a0f6557b8fd98f3967e859dbd7c694ef4"
+    name: Operational Multisig (2/3)
+    networks:
+      - mainnet
+    tags:
+      - safe
+  - address: "0xb2a3cf69c97afd4de7882e5fee120e4efc77b706"
+    name: Timelock (48hr)
+    networks:
+      - mainnet
+    tags:
+      - contract
+  - address: "0x4f2682b78f37910704fb1aff29358a1da07e022d"
+    name: Timelock (24hr)
+    networks:
+      - mainnet
+    tags:
+      - contract


### PR DESCRIPTION
# Add Strata (strata-markets)

Adds a new project entry for **Strata**, a structured-yield tranching protocol on Ethereum.

`data/projects/s/strata-markets.yaml`

## What it is

Strata splits the return of a yield-bearing asset into two tokenized tranches — a senior tranche (`srTOKEN`) taking a fixed, protected yield and a junior tranche (`jrTOKEN`) taking the variable remainder — so a depositor picks a risk-reward profile rather than accepting one blended rate. It runs seven markets: Ethena USDe, Neutrl NUSD, Midas mHYPER, Midas mM1-USD, Saturn USDat, Hastra PRIME and Nest nOPAL.

## Verification

- **Website:** https://strata.markets
- **Docs:** https://docs.strata.markets — the "Contracts Details" chapter publishes a per-market address table
- **X:** https://x.com/strata_markets — linked from the project's own docs alongside the website
- **GitHub:** https://github.com/Strata-Markets — org profile links back to `https://strata.markets`
- **Audits:** Quantstamp, Cyfrin and Guardian reports are linked from the docs

Every address in this entry was confirmed onchain with `eth_getCode` against Ethereum mainnet. The full published set is 97 addresses; the eight included here are the protocol entry points and the governance set, chosen to keep the entry readable rather than to enumerate every per-market contract.

## Notes for reviewers

**Slug choice.** `strata-markets`, not plain `strata`, for two reasons. First, `s/stratafoundation.yaml` already exists in this directory and is a *different* project — Strata Protocol / Wum.bo, a Solana token launchpad. Second, `strata-markets` matches this project's own GitHub org and its current domain: `strata.money` now 301s to `strata.markets`, and the old `strata-money` GitHub org carries the notice "This organization has moved. Please visit: https://github.com/Strata-Markets". This follows the domain-derived pattern of existing entries such as `backed-fi` and `the-arena-fun`.

**One address deliberately omitted.** The docs' "Trusted Addresses" table lists a Guardian at `0x277D26a45Add5775F21256159F089769892CEa5B`. Its code is 23 bytes — an EIP-7702 delegation designator (`0xef0100…`), i.e. an EOA that has delegated, not a deployed contract — so it is left out rather than tagged `contract` or `eoa` on a guess.

**Admin Multisig is Ethereum-only here, on purpose.** `0xA27cA929…` also answers `getOwners()` on Mantle, but with a different 3/4 owner set, so that is a same-factory-nonce address collision rather than a second Strata deployment. Only `mainnet` is claimed.

Checked before opening: no existing entry for this project (the only "strata" filename match is `stratafoundation`, a different org), `s/strata-markets.yaml` and `s/strata.yaml` both absent, none of these addresses appear anywhere in `data/projects/`, and the file validates against `src/resources/schema/project.json` with the `url.json` / `social-profile.json` / `blockchain-address.json` refs resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1D92Qfk2PdwVXFHZQwT3k
