### PR TITLE
Add NodeOps (nodeops)

### DIFF
--- a/data/projects/n/nodeops.yaml
+++ b/data/projects/n/nodeops.yaml
@@ -1,0 +1,84 @@
+version: 7
+name: nodeops
+display_name: NodeOps
+description: NodeOps Network is a chain-agnostic DePIN orchestration layer for general-purpose, economically-secured compute. Providers bond collateral to register machines, users subscribe to containerized one-click node deployments through the NodeOps Console, and the $NODE token settles the marketplace — with an order registry publishing revenue onchain and a dynamic mint-and-burn model tying emissions to verified network usage.
+websites:
+  - url: https://nodeops.network
+social:
+  twitter:
+    - url: https://x.com/NodeOpsHQ
+github:
+  - url: https://github.com/NodeOps-app
+blockchain:
+  - address: "0x2f714d7b9a035d4ce24af8d9b6091c07e37f43fb"
+    name: $NODE Token
+    networks:
+      - mainnet
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0xc0d2af6d32240494742ae486b9b73ec6dcc54aa1"
+    name: $NODE Wave-1 Airdrop Token (legacy)
+    networks:
+      - mainnet
+      - base
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0xff51a51f38f26bc03085642aa1a7082d7845c94d"
+    name: iAgent NFT
+    networks:
+      - mainnet
+      - base
+    tags:
+      - contract
+  - address: "0x2080fee444118afce30fcb749802c18c0a980db7"
+    name: Airdrop pool contract
+    networks:
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0xc02add3d60af95bd7652d68c7d510f0d52f994ef"
+    name: Order registry contract
+    networks:
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0x808a4650e2e27e0051db16c3089888cc92662e52"
+    name: Staking contract
+    networks:
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0xcdfc2cc484e5cf5669d34ba44260c83c4279f7b2"
+    name: Provider bonding contract (Arbitrum) / Ecosystem vesting (Ethereum)
+    networks:
+      - mainnet
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0x1bce1330e93d08f2996fdaed23a9168b9e3ed090"
+    name: NODE to credits (Arbitrum) / Incentives vesting (Ethereum)
+    networks:
+      - mainnet
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0x746038a17ebbb4298f0946cade01d80c09858240"
+    name: IDO contract
+    networks:
+      - mainnet
+    tags:
+      - contract
+  - address: "0xcba485746fe9a96e56f264c750c4025b135129df"
+    name: Airdrop vesting contract
+    networks:
+      - mainnet
+    tags:
+      - contract
+  - address: "0x708aa8eae215f9369c1caab30f259c4e193cd426"
+    name: Early backers vesting contract
+    networks:
+      - arbitrum_one
+    tags:
+      - contract


### PR DESCRIPTION
# Add NodeOps (nodeops)

Adds a new project entry for **NodeOps Network**, a DePIN compute-orchestration layer.

`data/projects/n/nodeops.yaml`

## What it is

Providers bond collateral to register machines, users subscribe to containerized one-click node deployments through the NodeOps Console, and the `$NODE` token settles the marketplace. An onchain order registry publishes revenue, and a dynamic mint-and-burn model ties emissions to verified network usage.

## Verification

- **Website:** https://nodeops.network
- **Docs:** https://docs.nodeops.network — publishes a `$NODE contracts` table and a token-address table
- **X:** https://x.com/NodeOpsHQ — linked three times from the project's own homepage, and set as `twitter_username` on the GitHub org profile
- **GitHub:** https://github.com/NodeOps-app — org profile links back to `https://nodeops.network`

Every `(address, network)` pair in this entry was confirmed with `eth_getCode` on that network.

## Notes for reviewers

**The networks here are from onchain checks, not from the docs' own Chain column** — that column is unreliable in both directions, so I verified rather than transcribed:

| Address | Docs say | Actually has code on |
|---|---|---|
| `0x708aa8eA…` | Bsc | Arbitrum One (16,596 bytes) |
| `0xc0d2af6d…` | Ethereum | Ethereum, Base **and** Arbitrum One |
| `0x2080FeE4…` | "the Ethereum address" in prose, `Arb` in the table | Arbitrum One only |

BNB Smart Chain deployments exist but are omitted because `bsc` is not in the `networks` enum in `src/resources/schema/blockchain-address.json`. Happy to add them if it is extended.

**Two addresses carry different roles on different chains**, so their `name` records both rather than picking one: `0xcDfC2Cc4…` is the Provider bonding contract on Arbitrum and the Ecosystem vesting contract on Ethereum; `0x1BCe1330…` is NODE-to-credits on Arbitrum and the Incentives vesting contract on Ethereum. If you would rather have one entry per role, I am glad to split them.

**Two addresses in the docs are deliberately excluded.** `0xaF7E3F16…` (VEMP) is a third-party token the docs only mention as bridgeable, not a NodeOps contract; `0xb5ead7a9…` is NodeOps' EigenLayer *operator* identity, which has no bytecode on any network.

Checked before opening: no existing entry or filename match for "nodeops" anywhere in `data/projects/`, `n/nodeops.yaml` absent, none of these addresses already claimed, and the file validates against `src/resources/schema/project.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1D92Qfk2PdwVXFHZQwT3k
