### PR TITLE
Add AI Arena (ai-arena)

### DIFF
--- a/data/projects/a/ai-arena.yaml
+++ b/data/projects/a/ai-arena.yaml
@@ -1,0 +1,46 @@
+version: 7
+name: ai-arena
+display_name: AI Arena
+description: AI Arena is a player-versus-player fighting game on Arbitrum One in which the characters are AI models rather than scripted opponents. Players train an NFT fighter by demonstration — the model learns the player's own combat style through imitation learning — and then enter it into autonomous ranked battles. NRN (Neuron) is the in-game token used for staking on ranked play and for rewards.
+websites:
+  - url: https://www.aiarena.io
+social:
+  twitter:
+    - url: https://twitter.com/aiarena_
+blockchain:
+  - address: "0xdadeca1167fe47499e53eb50f261103630974905"
+    name: Neuron (NRN)
+    networks:
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0x6371f51bd82d5e0eb2a01b942157cb45ab2d8ebe"
+    name: FighterFarm
+    networks:
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0xa4734bf76f511357d4353d88b84204957972ac84"
+    name: AAMintPass
+    networks:
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0xe5dd545c5be078f5e3f655db28e1de085fc5b26d"
+    name: AiArenaHelper
+    networks:
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0xb063f2af926af95f08515fd9d5f2397ce97148bf"
+    name: AirdropClaiming
+    networks:
+      - arbitrum_one
+    tags:
+      - contract
+  - address: "0xb0c41b1094120c9714bb8b9ec78bda5c464f628c"
+    name: ClaimingPatches
+    networks:
+      - arbitrum_one
+    tags:
+      - contract


### PR DESCRIPTION
# Add AI Arena (ai-arena)

Adds a new project entry for **AI Arena**, an AI-fighter PvP game on Arbitrum One.

`data/projects/a/ai-arena.yaml`

## What it is

The characters are AI models rather than scripted opponents. A player trains an NFT fighter by demonstration — the model picks up the player's own combat style through imitation learning — and then enters it into autonomous ranked battles. NRN (Neuron) is the in-game token used for ranked staking and rewards.

## Verification

- **Website:** https://www.aiarena.io
- **X:** https://twitter.com/aiarena_ — the only social account linked from the site itself

The game publishes no contracts page, so the six addresses here come from the deployment map the app's own same-origin JavaScript bundles carry (`JSON.parse('{"name":…,"address":"0x…","abi":[…]}')`), and each was then confirmed independently onchain:

| Contract | Address | Bytecode |
|---|---|---|
| Neuron (NRN) | `0xdadeca1167fe47499e53eb50f261103630974905` | 2,643 bytes |
| FighterFarm | `0x6371f51bd82d5e0eb2a01b942157cb45ab2d8ebe` | 16,262 bytes |
| AAMintPass | `0xa4734bf76f511357d4353d88b84204957972ac84` | 15,410 bytes |
| AiArenaHelper | `0xe5dd545c5be078f5e3f655db28e1de085fc5b26d` | 3,977 bytes |
| AirdropClaiming | `0xb063f2af926af95f08515fd9d5f2397ce97148bf` | 3,249 bytes |
| ClaimingPatches | `0xb0c41b1094120c9714bb8b9ec78bda5c464f628c` | 1,758 bytes |

Beyond `eth_getCode`, the map is confirmed by the contracts pointing at each other: `FighterFarm.neuronAddress()` returns the Neuron above, and `AAMintPass.fighterFarmContractAddress()` points back at FighterFarm. `AiArenaHelper` is not named in the bundle at all — it came from `FighterFarm.aiArenaHelperAddress()`.

## Notes for reviewers

**The bundle contains two environments.** Neuron, AirdropClaiming and ClaimingPatches each appear twice with different addresses — mainnet and an Arbitrum Sepolia twin — and the bundle does not label which is which. The three twins have no Arbitrum One bytecode and are excluded. `FighterFarm.mergingPoolAddress()` returns the zero address on this deployment, so no MergingPool entry is claimed.

**No `github:` section, on purpose.** Two orgs resolve by name and neither could be confirmed as this project: `github.com/aiarena` is the StarCraft II bot ladder at `aiarena.net`, a different thing entirely; `github.com/ArenaX-Labs` links to `competesai.com` and its public repos are RL evaluation tooling with none of this game's contracts. Left out rather than guessed at — happy to add it if the team confirms which is theirs.

Checked before opening: no existing entry or full-text match for "ai arena"/"aiarena" in `data/projects/`, `a/ai-arena.yaml` absent, none of these addresses already claimed, and the file validates against `src/resources/schema/project.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1D92Qfk2PdwVXFHZQwT3k
