### PR TITLE
Add AnyCampus (anycampus)

### DIFF
--- a/data/projects/a/anycampus.yaml
+++ b/data/projects/a/anycampus.yaml
@@ -1,0 +1,20 @@
+version: 7
+name: anycampus
+display_name: AnyCampus
+description: AnyCampus is a Web3 learn-to-earn platform where users earn rewards for studying and for contributing to the community. Learning activity and contributions accrue AnyCampus Points, and the platform accepts payment in ETH, USDC, USDT and NFTs through a payment contract deployed on each supported network.
+websites:
+  - url: https://anycampus.io
+social:
+  twitter:
+    - url: https://twitter.com/anycampus_io
+blockchain:
+  - address: "0x37f3855ef805739189cc2dd9f1435a6cd8af87ce"
+    name: AnyCampus Payment Contract
+    networks:
+      - mainnet
+      - optimism
+      - base
+      - arbitrum_one
+      - scroll
+    tags:
+      - contract


### PR DESCRIPTION
# Add AnyCampus (anycampus)

Adds a new project entry for **AnyCampus**, a Web3 learn-to-earn platform.

`data/projects/a/anycampus.yaml`

## What it is

Users earn rewards for studying and for contributing to the community; learning activity and contributions accrue AnyCampus Points. The platform takes payment in ETH, USDC, USDT and NFTs through a payment contract deployed on each supported network.

## Verification

- **Website:** https://anycampus.io
- **Docs:** https://docs.anycampus.io — its "Network and Currency" chapter publishes the per-network address table this entry is built from
- **X:** https://twitter.com/anycampus_io — linked from the project's own site and repeated in its docs

Each `(address, network)` pair was confirmed with `eth_getCode` on that network:

| Network | Chain ID | Bytecode |
|---|---|---|
| Ethereum | 1 | 711 bytes |
| OP Mainnet | 10 | 711 bytes |
| Base | 8453 | 1,100 bytes |
| Arbitrum One | 42161 | 1,100 bytes |
| Scroll | 534352 | 1,100 bytes |

The deployments are not bytecode-identical (711 vs 1,100 bytes) — different versions of the same contract across networks, which is why each pair was checked rather than inferred from one.

## Notes for reviewers

**Two networks in the docs are omitted:** Ink (57073) and Linea (59144) are not in the `networks` enum in `src/resources/schema/blockchain-address.json`. The Linea row also uses a different address (`0x655ee6ea…`), which has no bytecode on any network currently in the enum, so nothing is lost by leaving it out. Happy to add both if the enum is extended.

**The contract is named descriptively.** It exposes `owner()` but neither `name()` nor `symbol()`, and the docs table has no contract-name column — so "AnyCampus Payment Contract" describes its documented role rather than quoting an onchain string.

**No `github:` section:** no GitHub organisation is linked from the site or the docs, and none could be confirmed as belonging to this project. Left out rather than guessed at.

Checked before opening: no existing entry or full-text match for "anycampus" in `data/projects/`, `a/anycampus.yaml` absent, this address not already claimed anywhere in the directory, and the file validates against `src/resources/schema/project.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1D92Qfk2PdwVXFHZQwT3k
