### PR TITLE
Add Altura (altura-trade)

### DIFF
--- a/data/projects/a/altura-trade.yaml
+++ b/data/projects/a/altura-trade.yaml
@@ -1,0 +1,18 @@
+version: 7
+name: altura-trade
+display_name: Altura
+description: Altura is a multi-strategy yield protocol native to Hyperliquid. Users deposit USDT into a single vault and Altura allocates capital across hedged, market-neutral strategies — market making and liquidity provision, funding-rate and basis arbitrage, and real-world asset strategies — with returns reflected through a price-per-share model. AVLT is the vault token, also deployed on several other networks.
+websites:
+  - url: https://www.altura.trade
+github:
+  - url: https://github.com/AlturaTrade
+blockchain:
+  - address: "0x74db7a52773a52699dbc0c01b1254e5301e3e119"
+    name: AVLT (Altura Vault Tokens)
+    networks:
+      - mainnet
+      - optimism
+      - matic
+      - arbitrum_one
+    tags:
+      - contract


### PR DESCRIPTION
# Add Altura (altura-trade)

Adds a new project entry for **Altura**, a multi-strategy yield protocol.

`data/projects/a/altura-trade.yaml`

## What it is

Users deposit USDT into a single vault and Altura allocates capital across hedged, market-neutral strategies — market making and liquidity provision, funding-rate and basis arbitrage, and real-world asset strategies — with returns reflected through a price-per-share model. AVLT is the vault token.

## Verification

- **Website:** https://www.altura.trade
- **Docs:** https://docs.altura.trade — its "Supported Networks" chapter publishes the per-network AVLT address table this entry is built from
- **GitHub:** https://github.com/AlturaTrade — linked from the project's own docs, which point at `AlturaTrade/docs` for the vault and pre-deposit audit reports
- **Audits:** a Sherlock collaborative audit report (February 2026) is linked from the docs

Each `(address, network)` pair was confirmed twice — `eth_getCode` returns byte-identical 12,539-byte code on all four networks, and `symbol()` reads `AVLT` on each:

| Network | Chain ID |
|---|---|
| Ethereum | 1 |
| OP Mainnet | 10 |
| Polygon | 137 |
| Arbitrum One | 42161 |

Because one address repeats across networks, every pair was checked individually rather than inferred from a single deployment.

## Notes for reviewers

**Altura is native to Hyperliquid, which is why the vault machinery is not in this entry.** The project's own FAQ states that "all deposits, withdrawals, strategy execution, and PPS updates occur on the Hyperliquid chain". Hyperliquid is not in the `networks` enum in `src/resources/schema/blockchain-address.json`, so what is claimed here is the AVLT token as deployed on the four networks that are. The docs also list a second, HyperEVM-only AVLT address (`0xd0Ee0CF3…`) which has no bytecode on any network in the enum; it is omitted for that reason. Happy to add both if Hyperliquid is added.

**The "Supported Tokens" table is deliberately not parsed.** It lists the USDT/USDC/USD₮0 Altura *accepts* — Tether's and Circle's contracts, not Altura's — so this entry claims none of them.

**No `social:` section.** The Arbitrum ecosystem directory lists an X handle for Altura, but no X account is linked from the project's own site or docs, so I could not confirm it first-party and left it out rather than transcribe a third-party listing. Glad to add it if the team confirms.

Checked before opening: no existing entry or full-text match for "altura" in `data/projects/`, `a/altura-trade.yaml` absent, this address not already claimed, and the file validates against `src/resources/schema/project.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1D92Qfk2PdwVXFHZQwT3k
