### PR TITLE
Add Dæmons (daemons)

### DIFF
--- a/data/projects/d/daemons.yaml
+++ b/data/projects/d/daemons.yaml
@@ -1,0 +1,25 @@
+version: 7
+name: daemons
+display_name: Dæmons
+description: Dæmons is an AI-powered blockchain game by Ikigai Studios that turns a wallet's onchain history into a personalized interactive companion, in the spirit of Tamagotchi crossed with Pokémon. DMN is the game token and Daemons Playables are its omnichain (ONFT) character collection.
+websites:
+  - url: https://daemons.app
+social:
+  twitter:
+    - url: https://x.com/daemons_gamefi
+blockchain:
+  - address: "0x60c878d639593d3a2752182ac602ba7a4f5fdf02"
+    name: DMN Token
+    networks:
+      - base
+    tags:
+      - contract
+      - proxy
+  - address: "0x843b1327ef56d35dd71144cd256e76202f7406db"
+    name: Daemons Playables (ONFT Characters)
+    networks:
+      - optimism
+      - matic
+      - arbitrum_one
+    tags:
+      - contract


### PR DESCRIPTION
# Add Dæmons (daemons)

Adds a new project entry for **Dæmons**, an AI-companion blockchain game by Ikigai Studios.

`data/projects/d/daemons.yaml`

## What it is

Dæmons turns a wallet's onchain history into a personalized interactive companion — Tamagotchi crossed with Pokémon. DMN is the game token and Daemons Playables are its omnichain (ONFT) character collection.

## Verification

- **Website:** https://daemons.app
- **Docs:** https://docs.daemons.app — its disclosures page carries the "Smart Contract Addresses:" block this entry is built from
- **X:** https://x.com/daemons_gamefi — linked from the project's own docs
- **Audit:** Zokyo, October 2025, published for "Ikigai Studios Limited" at `zokyo-sec/audit-reports`

Each `(address, network)` pair was confirmed with `eth_getCode`, and both contracts identified by `name()`/`symbol()` onchain:

| Contract | Address | Networks | Onchain identity |
|---|---|---|---|
| DMN Token | `0x60c878d6…` | Base | `name()` = "Dæmons", `symbol()` = "DMN" |
| Daemons Playables (ONFT Characters) | `0x843b1327…` | OP Mainnet, Polygon, Arbitrum One | `name()` = "Daemon", `symbol()` = "DMN" |

## Notes for reviewers

**DMN on Base is tagged `proxy` as well as `contract`.** Its code is 44 bytes — an EIP-1167 minimal proxy delegating to `0x2bb625daa0a9dd2c69939cbd6c2dbae2ac6667ac`. It is still the token's canonical address (`name()`/`symbol()` resolve through it), so it is claimed here, with the proxy nature recorded in the tags.

**The ONFT's networks come from onchain checks, not from the docs.** The docs mention the collection via a MagicEden BSC link and OpenSea collections for Abstract, Optimism and Sei — not a deployment manifest. Checking every network in the enum found it live on OP Mainnet, Polygon **and** Arbitrum One; the latter two are not mentioned anywhere in the docs. BSC, Abstract, Sei and Somnia are not in the `networks` enum, so the Somnia-specific ONFT address (`0x2142664B…`) is omitted — it has no bytecode on any network currently in the enum.

**One address in the docs is deliberately excluded.** The "Vesting Contracts Deployed via Sablier" line links basescan with `?a=0xe261b366f231b12fcb58d6bbd71e57faee82431d`. That query parameter is a *holder* filter, and `name()` on that address returns "Sablier Lockup NFT" — it is Sablier's own contract, not Dæmons', so it is not claimed.

**No `github:` section, on purpose.** The only GitHub account tied to the project is `github.com/Ikigaicrypto`, a personal account (bio "Building Dæmons", blog `daemons.app`) whose sole public repo is an unrelated ecosystem-grants fork — no project code. The audit lives in the auditor's repo. Left out rather than pointing at an account with none of the project's source; happy to add an org if the team has one.

Checked before opening: no existing entry for this project (the "daemon" substring matches `blockdaemon` and unrelated files only), `d/daemons.yaml` absent, neither address already claimed, and the file validates against `src/resources/schema/project.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1D92Qfk2PdwVXFHZQwT3k
