### PR TITLE
Add Unitas (unitas)

### DIFF
--- a/data/projects/u/unitas.yaml
+++ b/data/projects/u/unitas.yaml
@@ -1,0 +1,21 @@
+version: 7
+name: unitas
+display_name: Unitas
+description: Unitas issues USDu, an overcollateralized yield-bearing stablecoin, along with its savings token sUSDu and XGLD (Unitas Gold), a gold-backed token redeemable against XAUt. USDu and sUSDu launched on Solana and BNB Smart Chain; XGLD mints natively on BNB Smart Chain and is bridged to other networks as a LayerZero OFT. Formerly Unipay.
+websites:
+  - url: https://unitas.so
+github:
+  - url: https://github.com/Unipayfi
+blockchain:
+  - address: "0xea953ea6634d55dac6697c436b1e81a679db5882"
+    name: XGLD (Unitas Gold)
+    networks:
+      - base
+    tags:
+      - contract
+  - address: "0x385c279445581a186a4182a5503094ebb652ec71"
+    name: XGLD (Unitas Gold)
+    networks:
+      - mantle
+    tags:
+      - contract


### PR DESCRIPTION
# Add Unitas (unitas)

Adds a new project entry for **Unitas**, a yield-bearing stablecoin issuer — formerly Unipay.

`data/projects/u/unitas.yaml`

## What it is

Unitas issues **USDu**, an overcollateralized yield-bearing stablecoin, its savings token **sUSDu**, and **XGLD** (Unitas Gold), a gold-backed token redeemable against XAUt. USDu and sUSDu launched on Solana and BNB Smart Chain; XGLD mints natively on BNB Smart Chain and bridges to other networks as a LayerZero OFT.

## Verification

- **Website:** https://unitas.so — `unipay.fi` now serves the Unitas site and its `og:url` points at `unitas.so`
- **Docs:** https://docs.unipay.fi (also served at `docs.unitas.so`) — publishes the token address tables this entry is built from
- **GitHub:** https://github.com/Unipayfi — linked from the project's own docs; holds `unitas-evm-contract`, `unitas-oracle`, `unitas-idl`, `boost-unitas-proxy` and `unitas-lz-token`

Both claimed pairs were confirmed onchain — same 13,191-byte code, `name()` = "Unitas Gold", `symbol()` = "XGLD":

| Network | Chain ID | Address |
|---|---|---|
| Base | 8453 | `0xea953ea6…` |
| Mantle | 5000 | `0x385c2794…` |

## Notes for reviewers

**The docs' Token column mislabels two addresses, so both entries are named from chain rather than from the table.** This is the main thing worth a reviewer's eye:

- `0xea953ea6…` is tabled twice — as USDu on BNB Smart Chain *and* as XGLD on Base. On Base it really is XGLD. It additionally has code on Ethereum (1,464 bytes) where the docs claim nothing, and `name()`/`symbol()` both revert there, so it is not a token at all — Ethereum is excluded as an address collision.
- `0x385c2794…` is tabled as **sUSDu on BNB Smart Chain**, but on Mantle it reports name "Unitas Gold", symbol "XGLD", and is **byte-identical to the Base XGLD** (same codehash). It is a real Unitas XGLD deployment the docs simply never list. Its `totalSupply()` is currently 0 — deployed, not yet bridged into. I have claimed it on that evidence; happy to drop it if the team says otherwise.

**Most of the project is out of scope for this schema.** USDu and sUSDu are Solana and BNB Smart Chain, and XGLD mints natively on BNB Smart Chain — none of which are in the `networks` enum in `src/resources/schema/blockchain-address.json`. The two XGLD OFT deployments above are the whole of the enum-representable surface today. **XAUt is excluded** entirely: it is Tether Gold, a third-party token Unitas accepts rather than issues.

**Slug choice.** `unitas` rather than `unipay`: the site, docs and token contracts all now brand as Unitas, with Unipay only surviving in the legacy domain and GitHub org name. The one substring match in the directory, `k/kommunitas-net.yaml`, is an unrelated project.

**No `social:` section.** No X account is linked from the project's own site or docs, so I could not confirm one first-party and left it out rather than transcribe a third-party listing.

Checked before opening: `u/unitas.yaml` absent, neither address already claimed anywhere in `data/projects/`, and the file validates against `src/resources/schema/project.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1D92Qfk2PdwVXFHZQwT3k
