### PR TITLE
Add Edilec

### DIFF
--- a/data/projects/e/edilec.yaml
+++ b/data/projects/e/edilec.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: edilec
+display_name: Edilec
+description: Edilec maintains open source Node.js tools for sitemap cohort auditing, HTML-safe inline JSON serialization, SVG semantic layout auditing, and content identity checks.
+websites:
+  - url: https://edilec.com/
+github:
+  - url: https://github.com/edilec/sitemap-cohort-auditor
+  - url: https://github.com/edilec/inline-json-for-html
+  - url: https://github.com/edilec/svg-semantic-layout-auditor
+  - url: https://github.com/edilec/content-identity-auditor


### PR DESCRIPTION
## Summary

Add Edilec as an open-source project and associate its four canonical public repositories:

- `sitemap-cohort-auditor`
- `inline-json-for-html`
- `svg-semantic-layout-auditor`
- `content-identity-auditor`

The entry also includes the official Edilec website.

## Validation

- `pnpm run validate`
- `pnpm lint`

Both completed successfully against the current `main` branch.

## Disclosure

I maintain the listed repositories and am submitting this entry from Edilec's official GitHub account.
