### PR TITLE
Add ELFi (elfi)

### DIFF
--- a/data/projects/e/elfi.yaml
+++ b/data/projects/e/elfi.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: elfi
+display_name: ELFi
+description: ELFi is a decentralised perpetual exchange with an equilibrium liquidity provider model, where liquidity providers mint and burn ELP tokens against a shared pool and traders open cross- or isolated-margin positions against it on Arbitrum and Base.
+websites:
+  - url: https://www.elfi.xyz
+social:
+  twitter:
+    - url: https://twitter.com/ELFiProtocol


### PR DESCRIPTION
Adds `elfi` — ELFi, a decentralised perpetual exchange.

**First-party sources**
- Website: https://www.elfi.xyz
- Docs: https://docs.elfi.xyz
- Contract addresses: https://docs.elfi.xyz/doc-api/contracts

**Contracts**, verified onchain rather than taken from the page alone — identical 6,692-byte deployments, and the Base address has no code on Arbitrum, so these are two distinct per-chain deployments:

| Chain | Address |
| --- | --- |
| Arbitrum | `0x153c613D572c050104086c7113d00B76Fbaa5d55` |
| Base | `0x957e0C2Ea128b0307B5730ff83e0bA508b729d50` |

The other addresses on that page (and all of `/doc-api/tokens`) are third-party tokens — USDC, WETH, ARB, LINK, USDT, WBTC — appearing inside Python code samples, and are not claimed here.

No logo included: the only first-party marks are an 88x88 `.ico` and two SVGs, and upscaling to 400x400 would be lossy. Glad to add one if you'd prefer.