### PR TITLE
Add Rho Labs (rho-labs)

### DIFF
--- a/data/projects/r/rho-labs.yaml
+++ b/data/projects/r/rho-labs.yaml
@@ -1,0 +1,6 @@
+version: 7
+name: rho-labs
+display_name: Rho Labs
+description: Rho Labs builds Rho X, a hybrid exchange for crypto-native interest rate derivatives, where traders take long or short exposure to funding rates and staking yields using stablecoin or ETH collateral.
+websites:
+  - url: https://www.rho.trading


### PR DESCRIPTION
Adds `rho-labs` — Rho Labs, which builds **Rho X**, a hybrid exchange for crypto-native interest rate derivatives (long/short exposure to funding rates and staking yields).

**First-party sources**
- Website: https://www.rho.trading
- Docs: https://docs.rho.trading
- Contract addresses: https://docs.rho.trading/developer/deployed-contracts

**Contracts** (Ethereum mainnet), as published on that page:

| Contract | Address |
| --- | --- |
| Router | `0x461FFa24b716f68C5a4fB583592F295DB5f7BA36` |
| ContractProvider | `0xFbb3C976302E2e58A5467887E9150A8083BDCD4a` |

**This is not the existing `rhomarkets` entry.** That one is Rho Markets, an unrelated consumer lending protocol on Scroll at rhomarkets.xyz. Different project, different chain, different team — hence a separate slug rather than an addition there.

Slug is the company (Rho Labs) rather than the product (Rho X), matching how `shipyard-software`, `lindy-labs` and `delvtech` are entered here.

No logo included: the only first-party marks are a 32x32 `.ico` and an SVG, and upscaling to 400x400 would be lossy. Happy to add one if you'd prefer.