### PR TITLE
Add SubnetDesk project

### DIFF
--- a/data/projects/s/subnetdesk-zibo-chen.yaml
+++ b/data/projects/s/subnetdesk-zibo-chen.yaml
@@ -1,0 +1,6 @@
+version: 7
+name: subnetdesk-zibo-chen
+display_name: SubnetDesk
+description: A LAN and VPN-only remote desktop application built with Rust and Flutter
+github:
+  - url: https://github.com/zibo-chen/SubnetDesk


### PR DESCRIPTION
## Summary

Add SubnetDesk, an AGPL-3.0 LAN and VPN-only remote desktop application built with Rust and Flutter, to the OSS Directory.

## Validation

- `pnpm lint`
- `pnpm run validate`