### PR TITLE
Add Universal (universal-xyz)

### DIFF
--- a/data/projects/u/universal-xyz.yaml
+++ b/data/projects/u/universal-xyz.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: universal-xyz
+display_name: Universal
+description: Universal is a wrapped asset protocol that issues tokenised versions of non-EVM cryptoassets (uBTC, uSOL, uXRP, uADA and others) as ERC-20s, backed one-for-one by reserves held with regulated custodians, so the assets can be traded from an onchain wallet.
+websites:
+  - url: https://www.universal.xyz
+social:
+  twitter:
+    - url: https://x.com/universaldotxyz


### PR DESCRIPTION
Adds `universal-xyz` — Universal, a wrapped asset protocol.

Universal issues tokenised versions of non-EVM cryptoassets (uBTC, uSOL, uXRP, uADA and ~90 others) as ERC-20s, backed one-for-one by reserves held with regulated custodians. Their own docs describe it as "Think Circle for cryptoassets".

**First-party sources**
- Website: https://www.universal.xyz
- Docs: https://docs.universal.xyz
- Contract addresses: https://docs.universal.xyz/docs/developers/contract-addresses (96 addresses)

**Contracts**, as evidence — a few of the tokenised assets, per that page:

| Asset | Address |
| --- | --- |
| uBTC | `0xF1143f3A8D76f1Ca740d29D5671d365F66C44eD1` |
| uSOL | `0x9B8Df6E244526ab5F6e6400d331DB28C8fdDdb55` |
| uXRP | `0x2615a94df961278DcbC41Fb0a54fEc5f10a693aE` |

The page states these are deployed on Base, Polygon, World Chain and Katana. No `blockchain:` section is asserted here, since I have not individually verified every asset on every one of those chains.

**Slug is domain-derived.** Plain `universal` would collide with the existing and unrelated `universaldot` and `universal-grave-yearone-io` entries, so `universal-xyz` follows the domain, as with `cometbridge` and `up33`.

No logo included: the only first-party mark I could find is a 48x48 `.ico`, and upscaling it to 400x400 would be visibly lossy. Glad to add one if you have a preferred source.