### PR TITLE
Add Variational (variational)

### DIFF
--- a/data/projects/v/variational.yaml
+++ b/data/projects/v/variational.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: variational
+display_name: Variational
+description: Variational is a peer-to-peer derivatives protocol on Arbitrum. Counterparties trade perpetuals on crypto, equities and commodities against shared settlement pools, with an omnibus liquidity pool providing the other side of the book.
+websites:
+  - url: https://variational.io
+social:
+  twitter:
+    - url: https://x.com/variational_io


### PR DESCRIPTION
Adds `variational` — Variational, a peer-to-peer derivatives protocol on Arbitrum.

**First-party sources**
- Website: https://variational.io
- Docs: https://docs.variational.io
- Contract addresses: https://docs.variational.io/technical-documentation/mainnet-contracts

**Contracts** (Arbitrum One), exactly as that page lists them, each linked to Arbiscan:

| Contract | Address |
| --- | --- |
| Protocol Treasury | `0x5e91b40467fb8902c46a7b6cb90482363188d645` |
| Core OLP Vault | `0x74bbbb0e7f0bad6938509dd4b556a39a4db1f2cd` |
| Settlement Pool Factory | `0x0F820B9afC270d658a9fD7D16B1Bdc45b70f074C` |
| Oracle | `0x84BE56470d45b7f6629A66A219a38681F6BA6172` |

No logo included: I could not find a square first-party mark at a usable size. Glad to add one if you have a preferred source.