### PR TITLE
Add EVEDEX (evedex)

### DIFF
--- a/data/projects/e/evedex.yaml
+++ b/data/projects/e/evedex.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: evedex
+display_name: EVEDEX
+description: EVEDEX is a decentralised derivatives exchange running on its own Arbitrum Orbit chain, offering perpetuals on crypto, forex, indices and metals, with account abstraction and paymasters so traders can transact without holding the gas token.
+websites:
+  - url: https://evedex.com
+social:
+  twitter:
+    - url: https://x.com/EveDexOfficial


### PR DESCRIPTION
Adds `evedex` — EVEDEX, a decentralised derivatives exchange (crypto, forex, indices, metals) running on its own Arbitrum Orbit chain.

**First-party sources**
- Website: https://evedex.com
- Docs: https://docs.evedex.com
- Contract addresses: https://docs.evedex.com/deployed-contracts

**Contracts.** The page lists ~40 addresses: most are on EVEDEX's own Orbit chain (`explorer.evedex.com`), and 11 are the Arbitrum-side rollup stack. A sample of the Arbitrum ones:

| Contract | Chain | Address |
| --- | --- | --- |
| Rollup | Arbitrum One | `0xD226Bd8D36725f4CE12961370211DFeEef1AbBbC` |
| Bridge | Arbitrum One | `0xad3026961087eccec0508d411bb9fb405e086b38` |
| SequencerInbox | Arbitrum One | `0x8696D32899e59F8a2ed76463cC0A0B07e56db025` |

These are EVEDEX's own Orbit deployment rather than Arbitrum One's canonical contracts — none collides with Arbitrum One's own Rollup/Bridge/SequencerInbox, and `SequencerInbox.bridge()` returns exactly the Bridge address above, so they form one coherent deployment.

No `blockchain:` section is asserted, since the majority of the contracts sit on a chain that is not in the networks enum.

No logo included: I could not find a square first-party mark at a usable size. Glad to add one if you have a preferred source.