### PR TITLE
Add GoldZip (goldzip)

### DIFF
--- a/data/projects/g/goldzip.yaml
+++ b/data/projects/g/goldzip.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: goldzip
+display_name: GoldZip
+description: GoldZip issues XGZ, an Ethereum ERC-20 token where each unit represents one gram of 99.99% fine gold held as assayed bars in recognised depositories, redeemable physically at 1,000 XGZ per eligible bar.
+websites:
+  - url: https://goldzip.info
+social:
+  twitter:
+    - url: https://x.com/goldzipxgz


### PR DESCRIPTION
Adds `goldzip` — GoldZip, a gold-backed token issuer.

XGZ is an ERC-20 on Ethereum where one unit represents one gram of 99.99% fine gold, held as assayed bars in recognised depositories and physically redeemable at 1,000 XGZ per eligible bar.

**First-party sources**
- Website: https://goldzip.info (publishes the token contract as an Etherscan link)
- Docs: https://goldzip-1.gitbook.io/goldzip — the [specifications page](https://goldzip-1.gitbook.io/goldzip/goldzip-xgz/what-is-usdxgz/specifications) states "**Blockchain:** Ethereum"

**Contract**, confirmed onchain rather than taken from the link alone:

| Token | Chain | Address | `symbol()` |
| --- | --- | --- | --- |
| XGZ | Ethereum | `0x69af64f409c08E9076bF7f3ed9Db3a7409717161` | `XGZ` |

No logo included: I could not find a square first-party mark at a usable size. Glad to add one if you have a preferred source.