### PR TITLE
Add Ample (ample-money)

### DIFF
--- a/data/projects/a/ample-money.yaml
+++ b/data/projects/a/ample-money.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: ample-money
+display_name: Ample
+description: Ample runs no-loss prize savings vaults. Depositors put tokens into an Ample vault, keep their principal, and the yield the vault earns funds weekly prize payouts drawn among depositors. Vaults are deployed on Ethereum, Base, Arbitrum and other EVM chains.
+websites:
+  - url: https://www.ample.money
+social:
+  twitter:
+    - url: https://x.com/AmpleHQ


### PR DESCRIPTION
Adds `ample-money` — Ample, a no-loss prize savings protocol.

Depositors put tokens into an Ample vault and keep their principal; the yield the vault earns funds weekly prize payouts drawn among depositors.

**First-party sources**
- Website: https://www.ample.money (the app publishes its vault registry in the page's own server-rendered state)
- `docs.ample.money` does not resolve, so the app itself is the address disclosure.

**Contracts**, confirmed onchain rather than taken from the payload alone — Ample's vaults name themselves with an `Ample` prefix:

| Vault | Chain | Address | `name()` |
| --- | --- | --- | --- |
| XAUt0 Vault | Arbitrum | `0x54a93a1399169877050efa784f9e533bb3bc170c` | Ample Arbitrum XAUt0 |
| XAUt Vault | Ethereum | `0x8d823ac5045474c845c8714b495d75b5ccb77d00` | — |

15 vaults are published in total, across Ethereum, Base, Arbitrum, BNB Chain, HyperEVM, Monad, Katana and Robinhood Chain. No `blockchain:` section is asserted here, since I have not individually verified every vault on every one of those chains.

**Slug is domain-derived.** Plain `ample` would collide with the existing and unrelated `ampleforth` entry, so `ample-money` follows the domain, as with `cometbridge`, `up33` and `universal-xyz`.

No logo included: I could not find a square first-party mark at a usable size. Glad to add one if you have a preferred source.