### PR TITLE
Add Cod3x (cod3x)

### DIFF
--- a/data/projects/c/cod3x.yaml
+++ b/data/projects/c/cod3x.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: cod3x
+display_name: Cod3x
+description: Cod3x builds onchain trading and yield infrastructure, including a perpetuals venue, the Cod3x Vault yield system and a capital-efficient CDP platform. CDX is its native token, used for staking and profit sharing.
+websites:
+  - url: https://cod3x.org
+github:
+  - url: https://github.com/Cod3x-Labs


### PR DESCRIPTION
Adds `cod3x` — Cod3x, onchain trading and yield infrastructure (a perpetuals venue, the Cod3x Vault yield system, and a CDP platform).

**First-party sources**
- Website: https://cod3x.org
- Docs: https://docs.cod3x.org
- GitHub: https://github.com/Cod3x-Labs (Cod3x-Vault, Cod3x-CDP, Reliquary, Options-Token — source only, no deployment manifests)
- Token address: https://docs.cod3x.org/cdx-token/what-is-cdx

**Contract**, confirmed onchain rather than taken from the page alone:

| Token | Chain | Address | `name()` | `symbol()` |
| --- | --- | --- | --- | --- |
| CDX | Base | `0xc0d3700000c0e32716863323bfd936b54a1633d1` | Cod3x Token | CDX |

Note the vanity prefix `0xc0d37…` matching the project name.

One caveat worth recording for anyone parsing that page: the "Contact Address" row's **cell text** is the CDX token above, while the row's **href** points at a GeckoTerminal liquidity pool (`0xb392363e…`). The pool is a third-party AMM contract holding CDX and is not claimed here.

No logo included: I could not find a square first-party mark at a usable size. Glad to add one if you have a preferred source.