### PR TITLE
Add GAIB (gaib)

### DIFF
--- a/data/projects/g/gaib.yaml
+++ b/data/projects/g/gaib.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: gaib
+display_name: GAIB
+description: GAIB tokenises financing for AI compute infrastructure. AID (AI Dollar) is its synthetic dollar backed by GPU-financing yield, sAID is the staked form, and minter and redeemer contracts handle issuance and redemption across Ethereum, Arbitrum, Base and BNB Chain.
+websites:
+  - url: https://gaib.ai
+social:
+  twitter:
+    - url: https://x.com/gaib_ai
+github:
+  - url: https://github.com/gaib-ai


### PR DESCRIPTION
Adds `gaib` — GAIB, which tokenises financing for AI compute infrastructure.

AID (AI Dollar) is its synthetic dollar backed by GPU-financing yield; sAID is the staked form; minter and redeemer contracts handle issuance and redemption.

**First-party sources**
- Website: https://gaib.ai
- Docs: https://docs.gaib.ai
- Contract addresses: https://docs.gaib.ai/products/gaib-products/aid-and-said-contracts

**Contracts**, as published on that page with per-chain explorer links:

| Contract | Chain | Address |
| --- | --- | --- |
| AID | Ethereum | `0x18F52B3fb465118731d9e0d276d4Eb3599D57596` |
| sAID | Ethereum | `0xB3B3c527BA57cd61648e2EC2F5e006A0B390A9F8` |
| Redeemer | Ethereum | `0x52323f33551188F170D8de14fE8d8423a839629d` |
| Minter (USDC) | Ethereum | `0xE2E1424687EB676b3807693CBb439362b8eA908E` |

AID uses the same address on Arbitrum, Base and BNB Chain. No `blockchain:` section is asserted here, since I have not individually verified every contract on every chain.

The `gaib-ai` GitHub org (16 repos) carries no deployment manifest, so the docs page is the address disclosure.

No logo included: I could not find a square first-party mark at a usable size. Glad to add one if you have a preferred source.