### PR TITLE
Add 0xbow (0xbow)

### DIFF
--- a/data/projects/0/0xbow.yaml
+++ b/data/projects/0/0xbow.yaml
@@ -1,0 +1,8 @@
+version: 7
+name: 0xbow
+display_name: 0xbow
+description: 0xbow builds Privacy Pools, a compliant privacy protocol for Ethereum. Depositors join an association set and prove membership when withdrawing, so funds can be shielded without joining a pool that includes known illicit deposits.
+websites:
+  - url: https://privacypools.com
+github:
+  - url: https://github.com/0xbow-io


### PR DESCRIPTION
Adds `0xbow` — 0xbow, the team behind **Privacy Pools**, a compliant privacy protocol on Ethereum. Depositors join an association set and prove membership when withdrawing, so funds can be shielded without joining a pool that includes known illicit deposits.

**First-party sources**
- Website: https://privacypools.com
- Docs: https://docs.privacypools.com
- GitHub: https://github.com/0xbow-io
- Deployed addresses: `0xbow-io/privacy-pools-core` → `docs/docs/deployments.md`

**Contracts** (Ethereum mainnet), confirmed onchain:

| Contract | Address |
| --- | --- |
| Entrypoint (Proxy) | `0x6818809eefce719e480a7526d76bd3e561526b46` |
| PrivacyPool ETH | `0xf241d57c6debae225c0f2e6ea1529373c9a9c9fb` |
| WithdrawalVerifier | `0x022891f938ae7fdc8ab9ead0fbf50aba8c897d6d` |
| RagequitVerifier | `0xa45aca8604a73d80c551faad6355a5c3a5565ec6` |

**Slug is the company, not the product.** 0xbow is the org that builds Privacy Pools, and "privacy pools" is a published concept rather than one project's name — so `0xbow` avoids claiming a generic term. This follows how Clipper is entered here as `shipyard-software` and Opus as `lindy-labs`.

Note for anyone reading that deployments page: its "Entrypoint (Implementation)" row is stale — the proxy's EIP-1967 implementation slot currently points at `0x15e355024de1cdc74addea7ebdf98418ba5b1a2c`, not the address listed. Only the proxy is claimed above.

No logo included: I could not find a square first-party mark at a usable size. Glad to add one if you have a preferred source.