### PR TITLE
Add Theo (theo)

### DIFF
--- a/data/projects/t/theo.yaml
+++ b/data/projects/t/theo.yaml
@@ -1,0 +1,9 @@
+version: 7
+name: theo
+display_name: Theo
+description: Theo runs institutional trading strategies onchain. thUSD is its dollar-denominated deposit token and sthUSD the staked form; mint, redeem and bridge contracts move deposits between Ethereum and the chains its strategies execute on.
+websites:
+  - url: https://theo.xyz
+social:
+  twitter:
+    - url: https://x.com/Theo_Network


### PR DESCRIPTION
Adds `theo` — Theo, which runs institutional trading strategies onchain. thUSD is its dollar-denominated deposit token and sthUSD the staked form.

**First-party sources**
- Website: https://theo.xyz
- Docs: https://docs.theo.xyz
- Deployed addresses: https://docs.theo.xyz/developers/deployed-addresses

That page is unusually well maintained — it states "Verified onchain August 28, 2026, and re-verified September 1, 2026" and links a [roles & access control](https://docs.theo.xyz/security-and-transparency/roles-and-access-control) page giving the commands to confirm ownership for each address.

**Contracts**, a sample of the 21 published (mostly Ethereum, with one each on Base, Arbitrum and HyperEVM):

| Contract | Chain | Address |
| --- | --- | --- |
| thUSD | Ethereum | `0xa3fE5c7596024E6811E14F029937D5bd8Ae485b3` |
| sthUSD | Ethereum | `0xA808Bc9775cb41c52C7842f8b50427fE7A770326` |

No `blockchain:` section is asserted, since I have not individually verified every contract on every chain.

Note `theopenxproject` already in this directory is a different, unrelated project (OpenX Swap on Optimism).

No logo included: I could not find a square first-party mark at a usable size. Glad to add one if you have a preferred source.