### PR TITLE
Add INFINIT (infinit)

### DIFF
--- a/data/projects/i/infinit.yaml
+++ b/data/projects/i/infinit.yaml
@@ -1,0 +1,6 @@
+version: 7
+name: infinit
+display_name: INFINIT
+description: INFINIT runs AI-managed DeFi vaults, where agents allocate deposited capital across lending markets and yield strategies. IN is its native token.
+websites:
+  - url: https://infinit.tech


### PR DESCRIPTION
Adds `infinit` — INFINIT, AI-managed DeFi vaults.

**First-party source**
- Website: https://infinit.tech (publishes the token contract as explorer links in the site header)
- Docs: https://docs.infinit.tech (developer docs; no address list)

**Contract**, confirmed onchain rather than taken from the link alone:

| Token | Chain | Address | `name()` | `symbol()` |
| --- | --- | --- | --- | --- |
| IN | Ethereum | `0x61fac5f038515572d6f42d4bcb6b581642753d50` | INFINIT | IN |

The same address is also listed on BNB Chain.

Note the existing `infinity-keys`, `infinity-wallet`, `infinitybase`, `infinityname` and `infinitywallet` entries are all different, unrelated projects.

No logo included: I could not find a square first-party mark at a usable size. Glad to add one if you have a preferred source.