### PR TITLE
Add SHAR Production Metadata Linter project

### DIFF
--- a/data/projects/p/production-metadata-linter-sharproduction.yaml
+++ b/data/projects/p/production-metadata-linter-sharproduction.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: production-metadata-linter-sharproduction
+display_name: SHAR Production Metadata Linter
+
+description: MIT-licensed CLI that validates rights-aware metadata for AI-hybrid video-production deliveries.
+
+websites:
+  - url: https://sharprod.com/
+
+github:
+  - url: https://github.com/SHARProduction/production-metadata-linter


### PR DESCRIPTION
Adds one schema-minimal project record for the existing public MIT-licensed SHAR Production Metadata Linter. All URLs point to the actual SHAR homepage and public source repository; no package, adoption, or ranking claims are included.