### PR TITLE
Add YYLO to the OSS Directory

### DIFF
--- a/data/projects/y/yylo-dev.yaml
+++ b/data/projects/y/yylo-dev.yaml
@@ -1,0 +1,11 @@
+version: 7
+name: yylo-dev
+display_name: YYLO
+description: YYLO is a command-line orchestrator for coding agents, repeatable workflows, and receipt-backed repository changes, with typed task, validation, merge, and release-readiness boundaries. The project also ships YYLO Ledger, an independent Git-native task store, and YYLO Benchmark, an independent evaluation and evidence package for coding-agent runs.
+websites:
+  - url: https://yylo.dev
+github:
+  - url: https://github.com/yylo-dev
+npm:
+  - url: https://www.npmjs.com/package/@yylo/benchmark
+  - url: https://www.npmjs.com/package/@yylo/cli


### PR DESCRIPTION
## Add YYLO to the OSS Directory

Adds a `version: 7` project file for **YYLO** at `data/projects/y/yylo-dev.yaml`, using the org-name pattern — all YYLO repos live under [github.com/yylo-dev](https://github.com/yylo-dev) (same shape as the `wevm` / `authier-pm` entries).

**Disclosure first:** I'm on the team that builds YYLO, and this submission was prepared with an AI coding agent following the repo's own `.claude/skills/add-project` contract (same up-front disclosure convention as the recent community adds #1213 / #1084).

### What's included

- **GitHub org** — `yylo-dev`: `yylo` (CLI), `yylo-ledger`, `yylo-benchmark`, `yylo-skills` (MIT, active daily)
- **npm artifacts** — [`@yylo/cli`](https://www.npmjs.com/package/@yylo/cli) (latest 0.2.2) and [`@yylo/benchmark`](https://www.npmjs.com/package/@yylo/benchmark) (latest 0.1.0). `@yylo/ledger` is not published to npm yet, so it is not listed.
- **Website** — https://yylo.dev

### Validation

- `pnpm validate:projects` → `Success! Validated 7176 projects` (run locally on this branch)
- `prettier --check data/projects/y/yylo-dev.yaml` → clean
- No blockchain addresses; no logo attached.

Happy to adjust the description or artifact list if anything looks off — and I'll run `/validate` per the merge checklist.
